### PR TITLE
Add support for data file mounts

### DIFF
--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -18,6 +18,7 @@ let findlib_deps = [
   "ppx_deriving.std";
   "ppx_deriving_yojson";
   "uuidm";
+  "base64";
 ]
 
 let lib : Project.item =

--- a/opam
+++ b/opam
@@ -32,6 +32,7 @@ depends: [
   "ppx_deriving"
   "ppx_deriving_yojson"
   "uuidm"
+  "base64"
 ]
 depopts: [
   "ketrew"

--- a/opam
+++ b/opam
@@ -20,9 +20,9 @@ install: [
 remove: []
 
 depends: [
-  "ocamlfind"
-  "ocamlbuild"
-  "solvuu-build"
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "solvuu-build" {build}
   "nonstd"
   "sosa"
   "pvem_lwt_unix"

--- a/src/lib/kube_job.ml
+++ b/src/lib/kube_job.ml
@@ -118,16 +118,6 @@ let start ~log t =
       @ [
         `Assoc [
           "apiVersion", `String "v1";
-          "kind", `String "Secret";
-          "metadata", `Assoc [
-            "name", `String (spec.id ^ "-secret")
-          ];
-          "data", `Assoc [
-            "secret-file", `String "dmFsdWUtMg0KDQo=";
-          ];
-        ];
-        `Assoc [
-          "apiVersion", `String "v1";
           "kind", `String "Pod";
           "metadata", `Assoc [
             "name", `String spec.id;
@@ -144,11 +134,6 @@ let start ~log t =
                 "command", `List (List.map spec.command ~f:(fun s -> `String s));
                 "volumeMounts",
                 `List (
-                  `Assoc [
-                    "name", `String (spec.id ^ "-secret" ^ "-volume");
-                    "readOnly", `Bool true;
-                    "mountPath", `String "/etc/secrets/";
-                  ] ::
                   List.map spec.volume_mounts ~f:(function
                     | `Constant f ->
                       `Assoc [
@@ -169,12 +154,6 @@ let start ~log t =
               ];
             ];
             "volumes", `List (
-              `Assoc [
-                "name", `String (spec.id ^ "-secret" ^ "-volume");
-                "secret", `Assoc [
-                  "secretName",  `String (spec.id ^ "-secret");
-                ]
-              ] ::
               List.map spec.volume_mounts ~f:(function
                 | `Constant f ->
                   `Assoc [
@@ -238,13 +217,6 @@ let get_status_json ~log t =
   command_must_succeed_with_output ~log t cmd
   >>= fun (out, _) ->
   return out
-(* let spec = t.specification in *)
-(* let open Specification in *)
-(* let tmp = Filename.temp_file "coclojob-status" ".json" in *)
-(* ksprintf Pvem_lwt_unix.System.Shell.do_or_fail *)
-(*   "kubectl get pod %s -o=json > %s" spec.id tmp *)
-(* >>= fun () -> *)
-(* Pvem_lwt_unix.IO.read_file tmp *)
 
 module Kube_status = struct
   (* cf. http://kubernetes.io/docs/user-guide/pod-states/ *)

--- a/src/lib/kube_job.ml
+++ b/src/lib/kube_job.ml
@@ -16,11 +16,24 @@ module Specification = struct
     let point m = m.point
     let read_only m = m.read_only
   end
+  module File_contents_mount = struct
+    type t = {
+      id: string;
+      path: string;
+      contents: string [@main];
+    } [@@deriving yojson, show, make]
+    let fresh ~path contents =
+      let id = Uuidm.(v5 (create `V4) "coclojobs" |> to_string ~upper:false) in
+      make ~id ~path contents
+    let id t = t.id
+    let path t = t.path
+    let contents t = t.contents
+  end
   type t = {
     id: string;
     image: string;
     command: string list;
-    volume_mounts: [ `Nfs of Nfs_mount.t ] list;
+    volume_mounts: [ `Nfs of Nfs_mount.t | `Constant of File_contents_mount.t ] list;
     memory: [ `GB of int ] [@default `GB 50];
     cpus: int [@default 7];
   } [@@deriving yojson, show, make]
@@ -85,47 +98,111 @@ let start ~log t =
       "cpu", `String (Int.to_string spec.cpus);
     ] in
   let json : Yojson.Safe.json =
-    `Assoc [
-      "kind", `String "Pod";
-      "apiVersion", `String "v1";
-      "metadata", `Assoc [
-        "name", `String spec.id;
-        "labels", `Assoc [
-          "app", `String spec.id;
-        ];
-      ];
-      "spec", `Assoc [
-        "restartPolicy", `String "Never";
-        "containers", `List [
-          `Assoc [
-            "name", `String (spec.id ^ "container");
-            "image", `String spec.image;
-            "command", `List (List.map spec.command ~f:(fun s -> `String s));
-            "volumeMounts",
-            `List (List.map spec.volume_mounts ~f:(fun (`Nfs m) ->
-                `Assoc [
-                  "name", `String (Nfs_mount.id m);
-                  "mountPath", `String (Nfs_mount.point m);
-                ])
-              );
-            "resources", `Assoc [
-              "requests", requests_json;
-            ];
+    let secrets =
+      List.filter_map spec.volume_mounts ~f:(function
+        | `Nfs _ -> None
+        | `Constant f ->
+          Some  (`Assoc [
+              "apiVersion", `String "v1";
+              "kind", `String "Secret";
+              "metadata", `Assoc [
+                "name", `String (File_contents_mount.id f);
+              ];
+              "data", `Assoc [
+                Filename.basename (File_contents_mount.path f),
+                `String (File_contents_mount.contents f |> B64.encode);
+              ];
+            ] )) in
+    let items =
+      secrets
+      @ [
+        `Assoc [
+          "apiVersion", `String "v1";
+          "kind", `String "Secret";
+          "metadata", `Assoc [
+            "name", `String (spec.id ^ "-secret")
+          ];
+          "data", `Assoc [
+            "secret-file", `String "dmFsdWUtMg0KDQo=";
           ];
         ];
-        "volumes", `List (
-          List.map spec.volume_mounts ~f:(fun (`Nfs m) ->
+        `Assoc [
+          "apiVersion", `String "v1";
+          "kind", `String "Pod";
+          "metadata", `Assoc [
+            "name", `String spec.id;
+            "labels", `Assoc [
+              "app", `String spec.id;
+            ];
+          ];
+          "spec", `Assoc [
+            "restartPolicy", `String "Never";
+            "containers", `List [
               `Assoc [
-                "name", `String (Nfs_mount.id m);
-                "nfs", `Assoc [
-                  "server", `String (Nfs_mount.host m);
-                  "path", `String (Nfs_mount.path m);
-                  "readOnly", `Bool (Nfs_mount.read_only m);
+                "name", `String (spec.id ^ "container");
+                "image", `String spec.image;
+                "command", `List (List.map spec.command ~f:(fun s -> `String s));
+                "volumeMounts",
+                `List (
+                  `Assoc [
+                    "name", `String (spec.id ^ "-secret" ^ "-volume");
+                    "readOnly", `Bool true;
+                    "mountPath", `String "/etc/secrets/";
+                  ] ::
+                  List.map spec.volume_mounts ~f:(function
+                    | `Constant f ->
+                      `Assoc [
+                        "name", `String (File_contents_mount.id f ^ "-volume");
+                        "readOnly", `Bool true;
+                        "mountPath", `String (Filename.dirname
+                                                (File_contents_mount.path f));
+                      ]
+                    | `Nfs m ->
+                      `Assoc [
+                        "name", `String (Nfs_mount.id m);
+                        "mountPath", `String (Nfs_mount.point m);
+                      ])
+                );
+                "resources", `Assoc [
+                  "requests", requests_json;
                 ];
-              ])
-        );
-      ];
-    ] in
+              ];
+            ];
+            "volumes", `List (
+              `Assoc [
+                "name", `String (spec.id ^ "-secret" ^ "-volume");
+                "secret", `Assoc [
+                  "secretName",  `String (spec.id ^ "-secret");
+                ]
+              ] ::
+              List.map spec.volume_mounts ~f:(function
+                | `Constant f ->
+                  `Assoc [
+                    "name", `String (File_contents_mount.id f ^ "-volume");
+                    "secret", `Assoc [
+                      "secretName",  `String (File_contents_mount.id f);
+                    ]
+                  ]   
+                | `Nfs m ->
+                  `Assoc [
+                    "name", `String (Nfs_mount.id m);
+                    "nfs", `Assoc [
+                      "server", `String (Nfs_mount.host m);
+                      "path", `String (Nfs_mount.path m);
+                      "readOnly", `Bool (Nfs_mount.read_only m);
+                    ];
+                  ])
+            );
+          ];
+        ];
+      ]
+    in
+    `Assoc [
+      "apiVersion", `String "v1";
+      "kind", `String "List";
+      "items", `List items;
+    ]
+  in
   let json_string = Yojson.Safe.pretty_to_string ~std:true json in
   let tmp = Filename.temp_file "coclojob" ".json" in
   Pvem_lwt_unix.IO.write_file tmp ~content:json_string

--- a/src/lib/kube_job.mli
+++ b/src/lib/kube_job.mli
@@ -1,8 +1,9 @@
 open Internal_pervasives
 
 module Specification : sig
-  module Nfs_mount : sig
-    type t = private {
+  module Nfs_mount :
+  sig
+    type t = {
       host : string;
       path : string;
       point : string;
@@ -18,27 +19,28 @@ module Specification : sig
     val point : t -> string
     val read_only : t -> bool
   end
-
-  type t = private {
-    id : string;
-    image : string;
-    command : string list;
-    volume_mounts : [ `Nfs of Nfs_mount.t ] list;
-    memory : [ `GB of int ];
-    cpus : int;
-  }[@@deriving yojson, show, make]
-
+  module File_contents_mount : sig
+    type t = { id : string; path : string; contents : string; }
+    val show : t -> Ppx_deriving_runtime.string
+    val make : id:string -> path:string -> string -> t
+    val fresh : path:string -> string -> t
+    val id : t -> string
+    val path : t -> string
+    val contents : t -> string
+  end
+  type t = {
+    id: string;
+    image: string;
+    command: string list;
+    volume_mounts: [ `Nfs of Nfs_mount.t | `Constant of File_contents_mount.t ] list;
+    memory: [ `GB of int ] [@default `GB 50];
+    cpus: int [@default 7];
+  } [@@deriving yojson, show, make]
   val id : t -> string
-  val make :
-    id:string ->
-    image:string ->
-    ?command:string list ->
-    ?volume_mounts:[ `Nfs of Nfs_mount.t ] list ->
-    ?memory:[ `GB of int ] -> ?cpus:int -> unit -> t
-
   val fresh :
     image:string ->
-    ?volume_mounts:[ `Nfs of Nfs_mount.t ] list -> string list -> t
+    ?volume_mounts:[ `Constant of File_contents_mount.t | `Nfs of Nfs_mount.t ] list ->
+    string list -> t
 end
 
 module Status : sig

--- a/src/test/workflow_test.ml
+++ b/src/test/workflow_test.ml
@@ -1,4 +1,6 @@
 
+open Nonstd
+
 let () =
   let wf =
     let open Ketrew.EDSL in
@@ -26,10 +28,32 @@ let () =
             )
         )
     in
+    let node3 =
+      workflow_node without_product
+        ~name:"coclobas test uses secret"
+        ~make:(
+          Coclobas_ketrew_backend.Plugin.create
+            ~base_url:"http://localhost:8082"
+            Coclobas.Kube_job.Specification.(
+              let path = "/ketrewkube/hello-world" in
+              let cool_file =
+                File_contents_mount.fresh
+                  ~path "Hello world!"
+              in
+              fresh ~image:"ubuntu"
+                ~volume_mounts:[`Constant cool_file]
+                ["bash"; "-c";
+                 sprintf "ls -la %s ;\
+                          cat %s "
+                   (Filename.dirname path) path]
+            )
+        )
+    in
     workflow_node without_product
       ~edges:[
         depends_on node1;
         depends_on node2;
+        depends_on node3;
       ]
   in
   Ketrew.Client.submit_workflow wf


### PR DESCRIPTION

Uses kubernetes secrets to mount constant data on the Kube-container, cf. test.

This is the first step of #8, we will put `Program.t` scripts in constant files, but it is a nice thing to have in general.

