### PR TITLE
Expose GZip-level in `Storage.make`

### DIFF
--- a/src/lib/storage.mli
+++ b/src/lib/storage.mli
@@ -18,7 +18,7 @@ module Error : sig
     string
 end
 
-val make : string -> t
+val make : ?gzip_level:int -> string -> t
 
 val update : t -> key -> value ->
   (unit,


### PR DESCRIPTION
This was useful for some benchmarks. For now I prefer keeping the
default level though.