### PR TITLE
Add a file-tree backend to the `Log` module

### DIFF
--- a/src/lib/command_line.ml
+++ b/src/lib/command_line.ml
@@ -4,8 +4,8 @@ let (//) = Filename.concat
 let db ~root =
   Storage.make (root // "db")
 let log ~root =
-  let st = Storage.make (root // "logs") in
-  Log.stored st
+  (* let st = Storage.make (root // "logs") in *)
+  Log.file_tree (root // "logs")
 
 let configure ~root ~cluster =
   let storage = db ~root in

--- a/src/lib/command_line.ml
+++ b/src/lib/command_line.ml
@@ -4,8 +4,7 @@ let (//) = Filename.concat
 let db ~root =
   Storage.make (root // "db")
 let log ~root =
-  (* let st = Storage.make (root // "logs") in *)
-  Log.file_tree (root // "logs")
+ Log.file_tree (root // "logs")
 
 let configure ~root ~cluster =
   let storage = db ~root in

--- a/src/lib/error.ml
+++ b/src/lib/error.ml
@@ -7,6 +7,7 @@ let to_string =
   | `Shell_command e ->
     sprintf "Shell-command failed:\n%s" (Hyper_shell.Error.to_display_string e)
   | `Storage e -> Storage.Error.to_string e
+  | `Log e -> Log.Error.to_string e
   | `IO (`Write_file_exn (path, e)) ->
     sprintf "Writing file %S: %s" path (exn e)
   | `IO (`Read_file_exn (path, e)) ->

--- a/src/lib/hyper_shell.mli
+++ b/src/lib/hyper_shell.mli
@@ -16,7 +16,7 @@ val command_must_succeed_with_output :
   string ->
   (string * string,
    [> `Shell_command of Error.t
-   | `Storage of [> Storage.Error.common] ])
+   | `Log of Log.Error.t ])
     Internal_pervasives.Deferred_result.t
 
 val command_must_succeed :
@@ -26,5 +26,5 @@ val command_must_succeed :
   string ->
   (unit,
    [> `Shell_command of Error.t
-   | `Storage of [> Storage.Error.common ] ])
+   | `Log of Log.Error.t ])
     Internal_pervasives.Deferred_result.t

--- a/src/lib/kube_cluster.ml
+++ b/src/lib/kube_cluster.ml
@@ -70,6 +70,6 @@ let ensure_living ~log t =
   | `Error (`Shell_command error)
     when error.Hyper_shell.Error.status = Some (`Exited 1) ->
     gcloud_start ~log t
-  | `Error ((`Shell_command _ | `Storage _) as e) ->
+  | `Error ((`Shell_command _ | `Log _) as e) ->
     fail e
   end

--- a/src/lib/kube_cluster.mli
+++ b/src/lib/kube_cluster.mli
@@ -30,32 +30,32 @@ val gcloud_start :
   t ->
   (unit,
    [> `Shell_command of Hyper_shell.Error.t
-   | `Storage of [> Storage.Error.common ] ]) Deferred_result.t
+   | `Log of Log.Error.t ]) Deferred_result.t
 
 val gcloud_delete :
   log:Log.t ->
   t ->
   (unit,
    [> `Shell_command of Hyper_shell.Error.t
-   | `Storage of [> Storage.Error.common ] ]) Deferred_result.t
+   | `Log of Log.Error.t ]) Deferred_result.t
 
 val gcloud_describe :
   log:Log.t ->
   t ->
   (string * string,
    [> `Shell_command of Hyper_shell.Error.t
-   | `Storage of [> Storage.Error.common ] ]) Deferred_result.t
+   | `Log of Log.Error.t ]) Deferred_result.t
 
 val gcloud_set_current :
   log:Log.t ->
   t ->
   (unit,
    [> `Shell_command of Hyper_shell.Error.t
-   | `Storage of [> Storage.Error.common ] ]) Deferred_result.t
+   | `Log of Log.Error.t ]) Deferred_result.t
 
 val ensure_living :
   log:Log.t ->
   t ->
   (unit,
    [> `Shell_command of Hyper_shell.Error.t
-   | `Storage of [> Storage.Error.common ] ]) Deferred_result.t
+   | `Log of Log.Error.t ]) Deferred_result.t

--- a/src/lib/kube_job.mli
+++ b/src/lib/kube_job.mli
@@ -81,35 +81,35 @@ val start :
   (unit,
    [> `IO of [> `Write_file_exn of Pvem_lwt_unix.IO.path * exn ]
    | `Shell_command of Hyper_shell.Error.t
-   | `Storage of [> Storage.Error.common ] ]) Deferred_result.t
+   | `Log of Log.Error.t ]) Deferred_result.t
 
 val describe :
   log:Log.t ->
   t ->
   (string,
    [> `Shell_command of Hyper_shell.Error.t
-   | `Storage of [> Storage.Error.common ] ]) Deferred_result.t
+   | `Log of Log.Error.t ]) Deferred_result.t
 
 val kill :
   log:Log.t ->
   t ->
   (unit,
    [> `Shell_command of Hyper_shell.Error.t
-   | `Storage of [> Storage.Error.common ] ]) Deferred_result.t
+   | `Log of Log.Error.t ]) Deferred_result.t
 
 val get_logs:
   log:Log.t ->
   t ->
   (string * string,
    [> `Shell_command of Hyper_shell.Error.t
-   | `Storage of [> Storage.Error.common ] ]) Deferred_result.t
+   | `Log of Log.Error.t ]) Deferred_result.t
 
 val get_status_json :
   log:Log.t ->
   t ->
   (string,
    [> `Shell_command of Hyper_shell.Error.t
-   | `Storage of [> Storage.Error.common ] ]) Deferred_result.t
+   | `Log of Log.Error.t ]) Deferred_result.t
 
 module Kube_status : sig
   type t = {

--- a/src/lib/log.ml
+++ b/src/lib/log.ml
@@ -6,10 +6,12 @@ type stored = {
 type t = [
   | `Silent
   | `Stored of stored
+  | `File_tree of string (* The root *)
 ]
 
 let silent : t = `Silent
 let stored storage : t = `Stored {storage}
+let file_tree root : t = `File_tree root
 
 let debug_sections : string list list ref = ref []
 let () =
@@ -20,22 +22,49 @@ let () =
           String.split ~on:(`Character '/') p |> List.filter ~f:((<>) ""))
   with _ -> ()
 
-let empty =
-  function
-  | `Silent -> return ()
-  | `Stored s -> Storage.empty s.storage
+module Error = struct
+  type t =
+    [ `IO of [ `Write_file_exn of string * exn ]
+    | `System of
+        [ `File_info of string
+        | `List_directory of string
+        | `Make_directory of string
+        | `Remove of string ] *
+        [ `Exn of exn | `Wrong_access_rights of int ]
+    | `Storage of  Storage.Error.common 
+    ]
+  let to_string =
+    function
+    | `IO _ as e -> Pvem_lwt_unix.IO.error_to_string e
+    | `System _ as s -> Pvem_lwt_unix.System.error_to_string s
+    | `Storage s -> Storage.Error.to_string s
+
+  let wrap m =
+    m >>< function `Ok o -> return o | `Error e -> fail (`Log e)
+end
+
+let empty l =
+  Error.wrap begin
+    match l with
+    | `Silent -> return ()
+    | `Stored s -> Storage.empty s.storage
+    | `File_tree root ->
+      let open Pvem_lwt_unix in
+      System.remove root
+      >>= fun () ->
+      System.ensure_directory_path root
+  end
 
 let log ?(section = ["main"]) t json =
-  match t with
-  | `Silent -> return ()
-  | `Stored st ->
-    let name =
-      let now = Unix.gettimeofday () in
-      sprintf "%s_%s"
-        (truncate (1000. *. now) |> Int.to_string)
-        (Hashtbl.hash json |> sprintf "%x")
-    in
-    let path = "logs" :: section @ [name ^ ".json"] in
+  Error.wrap begin
+    let path =
+      let name =
+        let now = Unix.gettimeofday () in
+        sprintf "%s_%s"
+          (truncate (1000. *. now) |> Int.to_string)
+          (Hashtbl.hash json |> sprintf "%x")
+      in
+      "logs" :: section @ [name ^ ".json"] in
     begin match List.mem section ~set:!debug_sections with
     | true ->
       printf "<<<< Coclobas.Log %s (%s)\n%s\n>>>>\n%!"
@@ -44,4 +73,14 @@ let log ?(section = ["main"]) t json =
         (Yojson.Safe.pretty_to_string json ~std:true);
     | false -> ()
     end;
-    Storage.Json.save_jsonable st.storage json ~path
+    match t with
+    | `Silent -> return ()
+    | `File_tree root ->
+      let path_str = String.concat ~sep:"/" (root :: path) in
+      Pvem_lwt_unix.System.ensure_directory_path (Filename.dirname path_str)
+      >>= fun () ->
+      let content = Yojson.Safe.pretty_to_string json ~std:true in
+      IO.write_file path_str ~content
+    | `Stored st ->
+      Storage.Json.save_jsonable st.storage json ~path
+  end

--- a/src/lib/log.mli
+++ b/src/lib/log.mli
@@ -4,15 +4,33 @@ type t
 val silent : t
 val stored : Storage.t -> t
 
+val file_tree: string -> t
+(** Store the logs as simple files, under a given root-path. *)
+
+module Error: sig
+
+  type t =
+    [ `IO of [ `Write_file_exn of string * exn ]
+    | `System of
+        [ `File_info of string
+        | `List_directory of string
+        | `Make_directory of string
+        | `Remove of string ] *
+        [ `Exn of exn | `Wrong_access_rights of int ]
+    | `Storage of  Storage.Error.common 
+    ]
+    val to_string: [< t ] -> string
+
+end
+
 val log :
   ?section:string list ->
   t ->
   Yojson.Safe.json ->
-  (unit,
-   [> `Storage of [> Storage.Error.common ] ]) Deferred_result.t
+  (unit, [> `Log of Error.t ]) Deferred_result.t
 
 val empty: t ->
-  (unit, [> `Storage of [> Storage.Error.common ] ]) Deferred_result.t
+  (unit, [> `Log of Error.t ]) Deferred_result.t
 
 val debug_sections : string list list ref
 (** Catch sections and display them on ["stdout"], cf. the [?section] argument of {!log}.

--- a/src/lib/server.ml
+++ b/src/lib/server.ml
@@ -135,8 +135,7 @@ let min_sleep = 3.
 let max_sleep = 180.
 
 let rec loop:
-  ?and_sleep : float ->
-  t -> (unit, [ `Storage of Storage.Error.common ]) Deferred_result.t
+  ?and_sleep : float -> t -> (unit, _) Deferred_result.t
   = fun ?(and_sleep = min_sleep) t ->
     let now () = Unix.gettimeofday () in
     let todo =
@@ -198,7 +197,8 @@ let rec loop:
     end
     >>= fun ((_ : unit list),
              (* We make sure only really fatal errors “exit the loop:” *)
-             (errors : [ `Storage of Storage.Error.common ] list)) ->
+             (errors : [ `Storage of Storage.Error.common
+                       | `Log of Log.Error.t ] list)) ->
     log_event t (`Loop_ends (and_sleep, errors))
     >>= fun () ->
     begin match errors with

--- a/src/lib/server.mli
+++ b/src/lib/server.mli
@@ -13,6 +13,7 @@ val create :
 val start: t ->
   (unit,
    [> `Shell_command of Hyper_shell.Error.t
+   | `Log of Log.Error.t
    | `Storage of [> Storage.Error.common
                  | `Missing_data of string
                  | `Of_json of string ] ]) Deferred_result.t


### PR DESCRIPTION
This also adds a proper `Log.Error.t` type and propagates it.

The Irmin-backend is still available.