### PR TITLE
Allow errors from `Kube_job.get_status_json`

### DIFF
--- a/src/lib/kube_job.ml
+++ b/src/lib/kube_job.ml
@@ -45,6 +45,7 @@ type t = {
   id: string;
   specification: Specification.t [@main];
   mutable status: Status.t [@default `Submitted];
+  mutable update_errors : string list;
 } [@@deriving yojson, show, make]
 
 let fresh spec =
@@ -73,7 +74,7 @@ let get st job_id =
     ~path:["job"; job_id; "status.json"]
     ~parse:Status.of_yojson
   >>= fun status ->
-  return {id = job_id; specification; status}
+  return {id = job_id; specification; status; update_errors = []}
 
 let command_must_succeed ~log ?additional_json job cmd =
   Hyper_shell.command_must_succeed ~log cmd ?additional_json

--- a/src/lib/kube_job.mli
+++ b/src/lib/kube_job.mli
@@ -51,7 +51,9 @@ end
 type t = {
   id: string;
   specification : Specification.t;
-  mutable status : Status.t; }
+  mutable status : Status.t;
+  mutable update_errors : string list;
+}
 
 val fresh : Specification.t -> t
 


### PR DESCRIPTION
For now we allow a maximum of 10 errors total.