### PR TITLE
Save outputs of `Kube_job.{describe,logs}`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.byte
 *.cma
 _build/
+/_test/

--- a/src/ketrew_backend/plugin.ml
+++ b/src/ketrew_backend/plugin.ml
@@ -21,13 +21,14 @@ module Run_parameters = struct
     |> Yojson.Safe.pretty_to_string ~std:true
 
   let deserialize_exn s =
+    let open Ppx_deriving_yojson_runtime.Result in
     Yojson.Safe.from_string s |> of_yojson
     |> function
-    | `Ok o -> o
-    | `Error e -> failwith e
+    | Ok o -> o
+    | Error e -> failwith e
 end
 
-let create ~base_url spec = 
+let create ~base_url spec =
   `Long_running (name, `Created (Client.make base_url, spec) |> Run_parameters.serialize)
 
 let run_program ~base_url ~image ?(volume_mounts = []) p =
@@ -54,20 +55,10 @@ module Long_running_implementation : Ketrew.Long_running.LONG_RUNNING = struct
 
   type run_parameters = Run_parameters.t
   include Run_parameters
-     
+
   let name = "coclobas-kube"
 
   module KLRU = Ketrew.Long_running_utilities
-
-  let serialize run_parameters =
-    Run_parameters.to_yojson run_parameters
-    |> Yojson.Safe.pretty_to_string ~std:true
-
-  let deserialize_exn s =
-    Yojson.Safe.from_string s |> Run_parameters.of_yojson
-    |> function
-    | `Ok o -> o
-    | `Error e -> failwith e
 
   let classify_client_error m =
     m >>< function

--- a/src/ketrew_backend/plugin.ml
+++ b/src/ketrew_backend/plugin.ml
@@ -232,8 +232,9 @@ module Long_running_implementation : Ketrew.Long_running.LONG_RUNNING = struct
           Client.get_kube_job_logs client [job_id]
           >>= fun l ->
           let rendered =
-            List.map l ~f:(fun (id, s) ->
-                sprintf "### Kube-Job %s\n\n%s" id  s)
+            List.map l ~f:(fun (`Id id, `Describe_output o, `Freshness frns) ->
+                sprintf "### Kube-Job %s\n### Freshness: %s\n### Output:\n\n%s"
+                  id frns o)
             |> String.concat ~sep:"\n"
           in
           return rendered

--- a/src/ketrew_backend/plugin.ml
+++ b/src/ketrew_backend/plugin.ml
@@ -221,7 +221,8 @@ module Long_running_implementation : Ketrew.Long_running.LONG_RUNNING = struct
           >>= fun l ->
           let rendered =
             List.map l ~f:(fun (`Id id, `Describe_output o, `Freshness frns) ->
-                sprintf "### Kube-Job %s\n### Freshness: %s\n\n\n%s" id frns o)
+                sprintf "### Kube-Job %s\n### Freshness: %s\n### Output:\n\n%s"
+                  id frns o)
             |> String.concat ~sep:"\n"
           in
           return rendered

--- a/src/ketrew_backend/plugin.ml
+++ b/src/ketrew_backend/plugin.ml
@@ -229,8 +229,8 @@ module Long_running_implementation : Ketrew.Long_running.LONG_RUNNING = struct
           Client.get_kube_job_descriptions client [job_id]
           >>= fun l ->
           let rendered =
-            List.map l ~f:(fun (id, s) ->
-                sprintf "### Kube-Job %s\n\n%s" id  s)
+            List.map l ~f:(fun (`Id id, `Describe_output o, `Freshness frns) ->
+                sprintf "### Kube-Job %s\n### Freshness: %s\n\n\n%s" id frns o)
             |> String.concat ~sep:"\n"
           in
           return rendered

--- a/src/lib/kube_job.ml
+++ b/src/lib/kube_job.ml
@@ -211,7 +211,7 @@ let save_command ~storage ~log t ~cmd ~path_kind =
     | `Error (`Shell_command _ as e) ->
       Storage.read storage (make_path (id t) path_kind)
       >>= begin function
-      | Some old -> return (`Old e, old)
+      | Some old -> return (`Archived e, old)
       | None -> fail e
       end
     | `Error e -> fail e

--- a/src/lib/kube_job.ml
+++ b/src/lib/kube_job.ml
@@ -56,22 +56,28 @@ let id t = t.id
 
 let status t = t.status
 
+let make_path id =
+  function
+  | `Specification -> ["job"; id; "specification.json"]
+  | `Status -> ["job"; id; "status.json"]
+  | `Describe_output -> ["job"; id; "describe.out"]
+
 let save st job =
   Storage.Json.save_jsonable st
-    ~path:["job"; id job; "specification.json"]
+    ~path:(make_path (id job) `Specification)
     (Specification.to_yojson job.specification)
   >>= fun () ->
   Storage.Json.save_jsonable st
-    ~path:["job"; id job; "status.json"]
+    ~path:(make_path (id job) `Status)
     (Status.to_yojson job.status)
 
 let get st job_id =
   Storage.Json.get_json st
-    ~path:["job"; job_id; "specification.json"]
+    ~path:(make_path job_id `Specification)
     ~parse:Specification.of_yojson
   >>= fun specification ->
   Storage.Json.get_json st
-    ~path:["job"; job_id; "status.json"]
+    ~path:(make_path job_id `Status)
     ~parse:Status.of_yojson
   >>= fun status ->
   return {id = job_id; specification; status; update_errors = []}
@@ -193,11 +199,23 @@ let start ~log t =
     (command_must_succeed ~additional_json ~log t)
     "kubectl create -f %s" tmp
 
-let describe ~log t =
+let describe ~storage ~log t =
   let cmd = sprintf "kubectl describe pod %s" (id t) in
-  command_must_succeed_with_output ~log t cmd
-  >>= fun (out, _) ->
-  return out
+  begin
+    command_must_succeed_with_output ~log t cmd
+    >>< function
+    | `Ok (out, _) ->
+      Storage.update storage (make_path (id t) `Describe_output) out
+      >>= fun () ->
+      return (`Fresh, out)
+    | `Error (`Shell_command _ as e) ->
+      Storage.read storage (make_path (id t) `Describe_output)
+      >>= begin function
+      | Some old -> return (`Old e, old)
+      | None -> fail e
+      end
+    | `Error e -> fail e
+  end
 
 let get_logs ~log t =
   let cmd = sprintf "kubectl logs %s" (id t) in

--- a/src/lib/kube_job.mli
+++ b/src/lib/kube_job.mli
@@ -99,11 +99,13 @@ val kill :
    | `Log of Log.Error.t ]) Deferred_result.t
 
 val get_logs:
+  storage:Storage.t ->
   log:Log.t ->
   t ->
-  (string * string,
-   [> `Shell_command of Hyper_shell.Error.t
-   | `Log of Log.Error.t ]) Deferred_result.t
+  ([ `Fresh | `Old of [ `Shell_command of Hyper_shell.Error.t ] ] * string,
+   [> `Log of Log.Error.t
+   | `Shell_command of Hyper_shell.Error.t
+   | `Storage of [> Storage.Error.common ] ]) Deferred_result.t
 
 val get_status_json :
   log:Log.t ->

--- a/src/lib/kube_job.mli
+++ b/src/lib/kube_job.mli
@@ -86,7 +86,7 @@ val describe :
   storage:Storage.t ->
   log:Log.t ->
   t ->
-  ([ `Fresh | `Old of [ `Shell_command of Hyper_shell.Error.t ] ] * string,
+  ([ `Fresh | `Archived of [ `Shell_command of Hyper_shell.Error.t ] ] * string,
    [> `Log of Log.Error.t
    | `Shell_command of Hyper_shell.Error.t
    | `Storage of [> Storage.Error.common ] ]) Deferred_result.t
@@ -102,7 +102,7 @@ val get_logs:
   storage:Storage.t ->
   log:Log.t ->
   t ->
-  ([ `Fresh | `Old of [ `Shell_command of Hyper_shell.Error.t ] ] * string,
+  ([ `Fresh | `Archived of [ `Shell_command of Hyper_shell.Error.t ] ] * string,
    [> `Log of Log.Error.t
    | `Shell_command of Hyper_shell.Error.t
    | `Storage of [> Storage.Error.common ] ]) Deferred_result.t

--- a/src/lib/kube_job.mli
+++ b/src/lib/kube_job.mli
@@ -86,11 +86,13 @@ val start :
    | `Log of Log.Error.t ]) Deferred_result.t
 
 val describe :
+  storage:Storage.t ->
   log:Log.t ->
   t ->
-  (string,
-   [> `Shell_command of Hyper_shell.Error.t
-   | `Log of Log.Error.t ]) Deferred_result.t
+  ([ `Fresh | `Old of [ `Shell_command of Hyper_shell.Error.t ] ] * string,
+   [> `Log of Log.Error.t
+   | `Shell_command of Hyper_shell.Error.t
+   | `Storage of [> Storage.Error.common ] ]) Deferred_result.t
 
 val kill :
   log:Log.t ->

--- a/src/lib/kube_job.mli
+++ b/src/lib/kube_job.mli
@@ -41,11 +41,8 @@ module Status : sig
     | `Finished of float * [ `Failed | `Succeeded | `Killed ]
     | `Started of float
     | `Submitted
-  ]
-  val to_yojson : t -> Yojson.Safe.json
-  val of_yojson : Yojson.Safe.json -> [ `Error of string | `Ok of t ]
+  ] [@@deriving yojson, show]
 
-  val show : t -> Ppx_deriving_runtime.string
 end
 
 type t = {
@@ -118,11 +115,7 @@ val get_status_json :
 module Kube_status : sig
   type t = {
     phase : [ `Failed | `Pending | `Running | `Succeeded | `Unknown ];
-  }
-  val show : t -> Ppx_deriving_runtime.string
-
-  val to_yojson : t -> Yojson.Safe.json
-  val of_yojson : Yojson.Safe.json -> [ `Error of string | `Ok of t ]
+  } [@@deriving yojson, show]
 
   val phase_of_string :
     string ->

--- a/src/lib/server.ml
+++ b/src/lib/server.ml
@@ -98,15 +98,16 @@ let change_job_list t action =
 
 let get_job_list t =
   let parse =
-    let open Pvem.Result in
+    let open Ppx_deriving_yojson_runtime in
+    let open Ppx_deriving_yojson_runtime.Result in
     function
     | `List l ->
-      List.fold ~init:(return []) l ~f:(fun prev j ->
+      Nonstd.List.fold ~init:(Ok []) l ~f:(fun prev j ->
           prev >>= fun l ->
           match j with
-          | `String s -> return (s :: l)
-          | other -> fail "expecting List of Strings")
-    | other -> fail "expecting List (of Strings)"
+          | `String s -> Ok (s :: l)
+          | other -> Error "expecting List of Strings")
+    | other -> Error "expecting List (of Strings)"
   in
   begin
     Storage.Json.get_json t.storage ~path:["server"; "jobs.json"] ~parse

--- a/src/lib/server.ml
+++ b/src/lib/server.ml
@@ -284,7 +284,7 @@ let make_json_of_freshness_result ~freshness ~id ~key ~value =
   let frstr =
     match freshness with
     | `Fresh -> "Fresh"
-    | `Old e -> sprintf "Old: %s" (Error.to_string e)
+    | `Archived e -> sprintf "Archived because of error: %s" (Error.to_string e)
   in
   (`Assoc [
       "id", `String id;

--- a/src/lib/server.ml
+++ b/src/lib/server.ml
@@ -159,6 +159,12 @@ let rec loop:
     >>= fun () ->
     Pvem_lwt_unix.Deferred_list.for_sequential todo ~f:begin function
     | `Remove j ->
+      (* We call these functions once to give them a chance to save the output
+         before Kubernetes forgets about the job: *)
+      (Job.get_logs ~storage:t.storage ~log:t.log j >>< fun _ -> return ())
+      >>= fun () ->
+      (Job.describe ~storage:t.storage ~log:t.log j >>< fun _ -> return ())
+      >>= fun () ->
       change_job_list t (`Remove j)
     | `Kill j ->
       begin

--- a/src/lib/server.ml
+++ b/src/lib/server.ml
@@ -291,11 +291,17 @@ let get_job_description t ids =
   Deferred_list.while_sequential ids ~f:(fun id ->
       Job.get t.storage id
       >>= fun job ->
-      Job.describe ~log:t.log job
-      >>= fun descr ->
+      Job.describe ~storage:t.storage ~log:t.log job
+      >>= fun (freshness, descr) ->
+      let frstr =
+        match freshness with
+        | `Fresh -> "Fresh"
+        | `Old e -> sprintf "Old: %s" (Error.to_string e)
+      in
       return (`Assoc [
           "id", `String id;
           "description", `String descr;
+          "freshness", `String frstr;
         ]))
   >>= fun l ->
   return (`Json (`List l))

--- a/src/lib/storage.ml
+++ b/src/lib/storage.ml
@@ -89,9 +89,11 @@ let empty t =
 
 
 module Json = struct
-  let of_yojson_error = function
-  | `Ok o -> return o
-  | `Error s -> fail (`Storage (`Of_json s))
+  let of_yojson_error =
+    let open Ppx_deriving_yojson_runtime.Result in
+    function
+    | Ok o -> return o
+    | Error s -> fail (`Storage (`Of_json s))
 
   let save_jsonable st ~path yo =
     let json = yo |> Yojson.Safe.pretty_to_string ~std:true in

--- a/src/lib/storage.mli
+++ b/src/lib/storage.mli
@@ -44,17 +44,19 @@ module Json : sig
       Deferred_result.t
 
   val parse_json_blob :
-    parse:(Yojson.Safe.json -> [ `Error of 'a | `Ok of 'b ]) ->
+    parse:(Yojson.Safe.json ->
+           ('a, string) Ppx_deriving_yojson_runtime.Result.result) ->
     string ->
-    ('b, [> `Storage of [> `Exn of exn | `Of_json of 'a ] ]) Deferred_result.t
+    ('a, [> `Storage of [> `Exn of exn | `Of_json of string ] ]) Deferred_result.t
 
   val get_json : t -> path:key ->
-    parse:(Yojson.Safe.json -> [ `Error of 'a | `Ok of 'b ]) ->
-    ('b,
+    parse:(Yojson.Safe.json ->
+           ('a, string) Ppx_deriving_yojson_runtime.Result.result) ->
+    ('a,
      [> `Storage of
           [> Error.common
           | `Missing_data of string
-          | `Of_json of 'a
+          | `Of_json of string
           ]])
       Deferred_result.t
 end


### PR DESCRIPTION
This is a first step twoards fixing #37.

I'm still testing this, and then I'll the same for `logs`.