### PR TITLE
Use `container-vm` GCloud image

### DIFF
--- a/src/lib/kube_cluster.ml
+++ b/src/lib/kube_cluster.ml
@@ -34,8 +34,11 @@ let command_must_succeed_with_output ~log cluster cmd =
 
 let gcloud_start ~log t =
   let cmd =
+    (* We use `--image-type=container_vm` because of some problem we have been
+       having with gcloud's new (Oct 2016) “GCI” default image. *)
     sprintf 
       "gcloud container clusters create %s \
+       --image-type=container_vm \
        --quiet --wait \
        --zone %s --num-nodes=%d --min-nodes=%d --max-nodes=%d \
        --machine-type=%s \


### PR DESCRIPTION
We've been having problems with the recent upgrade of the GKE
(cf. [release-notes](https://cloud.google.com/container-engine/release-notes)).

The problem seems to be the new VM image used by
[Google](https://cloud.google.com/container-engine/docs/node-image-migration)
which cannot mount NFS file-systems anymore.

This patch adds the option suggested at the
[end](https://cloud.google.com/container-engine/docs/node-image-migration#opting_out_of_using_container-vm_image)
of the documentation.
It has been tested and works like before (Kubernetes is 1.4 though), so we can
keep playing while we (or Google) figure out a longer term solution.