### PR TITLE
NetMHC conf: fix the name of the environment variable name for NetMHCcons

### DIFF
--- a/tools/docker/biokepi_machine.ml
+++ b/tools/docker/biokepi_machine.ml
@@ -44,7 +44,7 @@ let netmhc_tool_locations () = Biokepi.Setup.Netmhc.({
   netmhc=env_exn_tool_loc "NETMHC_TARBALL_URL" "NetMHC";
   netmhcpan=env_exn_tool_loc "NETMHCPAN_TARBALL_URL" "NetMHCpan";
   pickpocket=env_exn_tool_loc "PICKPOCKET_TARBALL_URL" "PickPocket";
-  netmhccons=env_exn_tool_loc "NETMHCPAN_TARBALL_URL" "NetMHCcons";
+  netmhccons=env_exn_tool_loc "NETMHCCONS_TARBALL_URL" "NetMHCcons";
 })
 
 let volume_mounts =


### PR DESCRIPTION
a few hours of clueless debugging on why netmhccons was not installing properly and I realized I had the wrong env variable name for the tool :\

![](https://media.giphy.com/media/4pMX5rJ4PYAEM/giphy.gif)