### PR TITLE
Allow a given number of starting errors

### DIFF
--- a/src/lib/kube_job.ml
+++ b/src/lib/kube_job.ml
@@ -46,6 +46,7 @@ type t = {
   specification: Specification.t [@main];
   mutable status: Status.t [@default `Submitted];
   mutable update_errors : string list;
+  mutable start_errors : string list;
 } [@@deriving yojson, show, make]
 
 let fresh spec =
@@ -81,7 +82,8 @@ let get st job_id =
     ~path:(make_path job_id `Status)
     ~parse:Status.of_yojson
   >>= fun status ->
-  return {id = job_id; specification; status; update_errors = []}
+  return {id = job_id; specification; status;
+          update_errors = []; start_errors = []}
 
 let command_must_succeed ~log ?additional_json job cmd =
   Hyper_shell.command_must_succeed ~log cmd ?additional_json

--- a/src/lib/kube_job.mli
+++ b/src/lib/kube_job.mli
@@ -50,6 +50,7 @@ type t = {
   specification : Specification.t;
   mutable status : Status.t;
   mutable update_errors : string list;
+  mutable start_errors : string list;
 }
 
 val fresh : Specification.t -> t


### PR DESCRIPTION
This makes some `kubectl` weird errors more tolerable:
https://github.com/hammerlab/coclobas/issues/62


Just noting that the internal Json serialization changed so this is not backwards compatible at the DB level.


Also the screen shot here is actually a test :)
https://github.com/hammerlab/coclobas/issues/65