### PR TITLE
Add more backoff from start/update errors

### DIFF
--- a/src/lib/command_line.ml
+++ b/src/lib/command_line.ml
@@ -200,9 +200,10 @@ let main () =
       (`Max_update_errors max_update_errors)
       (`Concurrent_steps concurrent_steps)
       (`Min_sleep min_sleep)
-      (`Max_sleep max_sleep) ->
+      (`Max_sleep max_sleep)
+      (`Backoff_factor backoff_factor) ->
       Server.Configuration.make ()
-        ~min_sleep ~max_sleep ~max_update_errors
+        ~min_sleep ~max_sleep ~max_update_errors ~backoff_factor
     end
     $ begin
       pure (fun s -> `Max_update_errors s)
@@ -232,6 +233,14 @@ let main () =
              info ["min-sleep"]
                ~doc:"The maximal time to wait before reentering the \
                      “update loop.”")
+    end
+    $ begin
+      pure (fun s -> `Backoff_factor s)
+      $ Arg.(value & opt float Server.Configuration.Default.backoff_factor &
+             info ["backoff-factor"]
+               ~doc:"The factor used for exponential backoff: \
+                     (factor * nth-error) in seconds, see also discussion \
+                     at pull-request #96.")
     end
   in
   let configure =

--- a/src/lib/job.mli
+++ b/src/lib/job.mli
@@ -22,22 +22,26 @@ type t
 val show : t -> string
  
 val make :
-  id:string ->
-  ?status:Status.t ->
-  ?update_errors:string list ->
-  ?start_errors:string list -> Specification.t -> t
+  id: string ->
+  ?status: Status.t ->
+  ?update_errors: string list ->
+  ?start_errors: string list ->
+  ?latest_error: float ->
+  Specification.t -> t
 
 val id : t -> string
 val status : t -> Status.t
 val fresh : Specification.t -> t
 
-val set_status : t -> Status.t -> unit
+val set_status : t -> from_error: bool -> Status.t -> unit
 
 val start_errors : t -> string list
-val set_start_errors : t -> string list -> unit
+val set_start_errors : t -> time: float -> string list -> unit
 
 val update_errors : t -> string list
-val set_update_errors : t -> string list -> unit
+val set_update_errors : t -> time: float -> string list -> unit
+
+val latest_error: t -> float option
 
 val save :
   Storage.t ->

--- a/src/lib/server.mli
+++ b/src/lib/server.mli
@@ -7,6 +7,7 @@ module Configuration : sig
     val max_sleep : float
     val max_update_errors : int
     val concurrent_steps : int
+    val backoff_factor : float
   end
 
   type t = {
@@ -14,6 +15,7 @@ module Configuration : sig
     max_sleep: float [@default Default.max_sleep];
     max_update_errors: int [@default Default.max_update_errors];
     concurrent_steps: int [@default Default.concurrent_steps];
+    backoff_factor : float [@default Default.backoff_factor];
   } [@@deriving make, yojson, show]
 
   val save :


### PR DESCRIPTION
This is for #95.

The current “formula” for the backoff is `number-of-errors × 30 seconds`,
that maybe too much.