### PR TITLE
Add AWS-Batch support (issue #94)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,17 @@ Coclobas
 
 Coclobas is a scheduler for HPC-like jobs accessible through HTTP.
 
-It can be setup with two kinds of configurations:
+It can be setup with three kinds of configurations:
 
 - Using Kubernetes and the *Google Container Engine*,
   i.e. using a Kubernetes “eleastic” cluster setup with `gcloud` and submitting
   jobs as Kubernetes “pods”.
 - Using the server's machine as a one-node cluster and submitting jobs as docker
   containers given a maximal number of jobs.
+- *(Experimental)* using an AWS-Batch job queue with Docker containers.
 
-Coclobas provides logging facilities (e.g. maintaining logs long after Kubernetes
-disposes of them).
+Coclobas provides logging facilities (e.g. maintaining logs long after
+Kubernetes disposes of them).
 
 Finally, it makes it easy to submit arbitrary scripts to be run in any Docker
 container, which makes it easier than using raw Kubernetes or Docker to submit
@@ -28,8 +29,6 @@ Build
 -----
 
 Coclobas 0.0.1 is in `opam` (supports GKE/Kubernetes and local-docker modes).
-
-Coclobas depends on `solvuu-build`, `sosa`, `nonstd`, and optionally `ketrew`.
 
 You can just use Opam to get things going quickly:
 
@@ -48,6 +47,8 @@ must be installed (and authenticated) with the Coclobas server.
 In Local/Docker mode, `docker` must be present (and accessible to the Coclobas
 server's user).
 
+In AWS-Batch mode, the `aws` command line application must be present (and
+it must be recent enough to have `aws batch` enabled).
 
 Using Coclobas
 --------------
@@ -71,6 +72,15 @@ Example 2: Local/Docker mode:
     coclobas config --root $root \
              --cluster-kind local-doker \
              --max-nodes 5
+
+Example 3: AWS-Batch mode:
+
+    coclobas config --root $root \
+        --cluster-kind aws-batch \
+        --aws-queue awsuser-jq01 \
+        --min-sleep 4 \
+        --max-update-errors 4 \
+        --max-nodes 4
 
 ### Start The Server
 

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -55,6 +55,7 @@ let generate_meta_data () =
 let lib : Project.item =
   Project.lib project_name
     ~thread:()
+    ~bin_annot:()
     ~findlib_deps
     ~ml_files:(`Add [Filename.basename meta_dot_ml])
     ~dir:"src/lib"
@@ -64,6 +65,7 @@ let ketrew_backend : Project.item option =
   let item =
     Project.lib (project_name ^ "_ketrew_backend")
       ~thread:()
+      ~bin_annot:()
       ~findlib_deps:("ketrew" :: findlib_deps)
       ~dir:"src/ketrew_backend"
       ~style:(`Pack (project_name ^ "_ketrew_backend"))
@@ -80,14 +82,20 @@ let app : Project.item =
     ~file:"src/app/main.ml"
     ~internal_deps:[lib]
 
+let test_findlib_deps = [
+  "ppx_deriving_cmdliner"
+]
+
 let test : Project.item option =
   if build_tests
   then Some (
       Project.app (project_name ^ "-test")
         ~thread:()
+        ~bin_annot:()
         ~file:"src/test/client_server.ml"
         ~install:`No
         ~internal_deps:[lib]
+        ~findlib_deps:test_findlib_deps
     ) else None
 
 let linked_ketrew : Project.item option =
@@ -96,6 +104,7 @@ let linked_ketrew : Project.item option =
     Some (
       Project.app (project_name ^ "-ketrew")
         ~thread:()
+        ~bin_annot:()
         ~file:"src/test/cocloketrew.ml"
         ~internal_deps:[lib; kb]
     )
@@ -107,9 +116,11 @@ let test_ketrew_workflow : Project.item option =
     Some (
       Project.app (project_name ^ "-ketrew-workflow-test")
         ~thread:()
+        ~bin_annot:()
         ~install:`No
         ~file:"src/test/workflow_test.ml"
         ~internal_deps:[lib; kb]
+        ~findlib_deps:test_findlib_deps
     )
   | _, _ -> None
 

--- a/src/lib/aws_batch_job.ml
+++ b/src/lib/aws_batch_job.ml
@@ -1,0 +1,159 @@
+
+open Internal_pervasives
+
+module Specification = struct
+  (* Cf.
+     http://docs.aws.amazon.com/batch/latest/APIReference/API_ContainerProperties.html
+  *)
+  type t = {
+    image: string;
+    memory: [ `MB of int ] [@default `MB 128];
+    cpus: int [@default 7];
+    job_role: [ `Arn of string ] option;
+    priviledged: bool [@default false];
+    command: string list [@main];
+    (* Mounting volumes seems to be only for host directories. *)
+    (* volume_mounts: [ `Nfs of Nfs_mount.t | `Constant of File_contents_mount.t ] list; *)
+  } [@@deriving yojson, show, make]
+end
+
+module State = struct
+  type t = {
+    aws_id: string;
+  } [@@deriving yojson, show, make]
+end
+
+module Error = struct
+  type nonrec exn = exn [@@deriving show]
+  type start = [
+      `Start of string * Specification.t *
+                [ `Json_parsing of
+                    string * [ `Exn of exn | `String of string ]
+                | `Wrong_cluster of Cluster.t ]
+  ] [@@deriving show]
+  let start ~id ~specification e =
+    `Aws_batch_job (`Start (id, specification, e))
+  type status = [
+      `Status of [`Id of string] * [ `Aws_id of string ]
+                 * [ `Parsing_status of string ]
+  ] [@@deriving show]
+  let status ~id ~aws_id e =
+    `Aws_batch_job (`Status (`Id id, `Aws_id aws_id, e))
+  type t = [ start | status ] [@@deriving show]
+end
+
+let command_must_succeed ~log ?additional_json ~id cmd =
+  Hyper_shell.command_must_succeed ~log cmd ?additional_json
+    ~section:["job"; id; "commands"]
+let command_must_succeed_with_output ~log ?additional_json ~id cmd =
+  Hyper_shell.command_must_succeed_with_output ~log cmd ?additional_json
+    ~section:["job"; id; "commands"]
+
+let job_definition id = sprintf "coclodef-%s" id
+let job_name id = sprintf "coclojob-%s" id
+
+let start ~cluster ~log ~id ~specification =
+  let string s : Yojson.Safe.json = `String s in
+  let int s : Yojson.Safe.json = `Int s in
+  let json =
+    let open Specification in
+    let props =
+      [
+        "image", string specification.image;
+        "vcpus", int specification.cpus;
+        "memory", int (specification.memory |> fun (`MB i) -> i);
+        "command", `List (List.map ~f:string specification.command);
+        "privileged", `Bool specification.priviledged;
+      ]
+      @ Option.value_map ~default:[] specification.job_role ~f:(function
+        | `Arn s -> ["jobRoleArn", string s])
+    in
+    `Assoc props in
+  Cluster.( match cluster with
+    | Kube _
+    | Local_docker _ ->
+      fail (Error.start ~id ~specification (`Wrong_cluster cluster))
+    | Aws_batch_queue q ->
+      Aws_batch_queue.queue_name q |> return)
+  >>= fun job_queue ->
+  ksprintf
+    (command_must_succeed ~log ~id)
+    "aws batch register-job-definition --job-definition %s \
+     --type container \
+     --container-properties %s
+    "
+    (job_definition id)
+    (Filename.quote (Yojson.Safe.to_string ~std:true json))
+  >>= fun () ->
+  ksprintf
+    (command_must_succeed_with_output ~log ~id)
+    "aws batch submit-job --job-name %s --job-queue %s --job-definition %s"
+    (job_name id) job_queue (job_definition id)
+  >>= fun (out, err) ->
+  Deferred_result.wrap_deferred
+    ~on_exn:(fun e -> 
+      Error.start ~id ~specification (`Json_parsing (out, `Exn e)))
+    (fun () -> Yojson.Safe.from_string out |> Lwt.return)
+  >>= fun json ->
+  let job_id_opt =
+    match json with
+    | `Assoc l ->
+      List.find_map l ~f:(function
+        | ("jobId", `String v) -> Some v
+        | other -> None)
+    | other -> None
+  in
+  begin match job_id_opt with
+  | None ->
+    fail (Error.start ~id ~specification
+            (`Json_parsing (out, `String "Can't find jobId")))
+  | Some v -> return v
+  end
+  >>= fun aws_id ->
+  return { State.aws_id }
+
+let get_update ~log ~id ~state =
+  ksprintf
+    (command_must_succeed_with_output ~log ~id)
+    "aws batch describe-jobs --jobs %s  --query 'jobs[0].status'"
+    state.State.aws_id
+  >>= fun (out, err) ->
+  let status =
+    String.filter out ~f:(function '"' | '\n' | ' ' -> false | _ -> true) in
+  begin match status with
+  | "SUBMITTED"
+  | "PENDING"
+  | "RUNNABLE"
+  | "STARTING"
+  | "RUNNING" -> return `Running
+  | "SUCCEEDED" -> return `Succeeded
+  | "FAILED" -> return `Failed
+  | _ ->
+    fail (Error.status ~id ~aws_id:state.State.aws_id (`Parsing_status status))
+  end
+
+let describe ~log ~id ~state =
+  ksprintf
+    (command_must_succeed_with_output ~log ~id)
+    "aws batch describe-jobs --jobs %s"
+    state.State.aws_id
+  >>= fun (out, err) ->
+  return (`Fresh, out)
+
+let get_logs ~log ~id ~state =
+  let cloudwatch_url =
+    sprintf
+      "https://console.aws.amazon.com/cloudwatch/home?\
+       region=us-east-1#logStream:group=/aws/batch/job;prefix=%s/%s/;\
+       streamFilter=typeLogStreamPrefix"
+      (job_name id) state.State.aws_id
+  in
+  return (`Fresh, cloudwatch_url)
+
+let kill ~log ~id ~state =
+  ksprintf
+    (command_must_succeed ~log ~id)
+    "aws batch terminate-job --job-id %s --reason %s"
+    state.State.aws_id
+    (ksprintf Filename.quote "Killed by Coclobas on %s"
+       ODate.Unix.(now () |> Printer.to_iso))

--- a/src/lib/aws_batch_queue.ml
+++ b/src/lib/aws_batch_queue.ml
@@ -1,0 +1,38 @@
+open Internal_pervasives
+
+type t = {
+  max_jobs: int;
+  queue_name: string;
+} [@@deriving make, yojson, show]
+
+let max_started_jobs t = t.max_jobs
+
+let queue_name t = t.queue_name
+
+let command_must_succeed ~log cluster cmd =
+  Hyper_shell.command_must_succeed ~log cmd
+    ~section:["cluster"; "commands"]
+    ~additional_json:[
+      "cluster", to_yojson cluster
+    ]
+
+let command_must_succeed_with_output ~log cluster cmd =
+  Hyper_shell.command_must_succeed_with_output ~log cmd
+    ~section:["cluster"; "commands"]
+    ~additional_json:[
+      "cluster", to_yojson cluster
+    ]
+
+let ensure_living t ~log =
+  let cmd =
+    sprintf "aws batch describe-job-queues \
+             --job-queues %s \
+             --query jobQueues[0].status --output text"
+      t.queue_name in
+  command_must_succeed_with_output ~log t cmd
+  >>= fun (out, err) ->
+  begin match out with
+  | "VALID\n" -> return ()
+  | other -> fail (`Aws_batch_queue (`Check_valid, other, err))
+  end
+

--- a/src/lib/cluster.ml
+++ b/src/lib/cluster.ml
@@ -71,6 +71,6 @@ let describe ~log =
   function
   | Kube k -> Gke_cluster.gcloud_describe ~log k
   | Local_docker _ as t -> return (display_name t, "")
-  | Aws_batch_queue a ->
+  | Aws_batch_queue _ as t ->
     return (display_name t, "")
 

--- a/src/lib/cluster.ml
+++ b/src/lib/cluster.ml
@@ -7,12 +7,14 @@ type local_docker =
 type t =
   | Kube of Gke_cluster.t
   | Local_docker of local_docker
+  | Aws_batch_queue of Aws_batch_queue.t
 [@@deriving yojson, show]
 
 let kind =
   function
   | Kube _ -> `GCloud_kubernetes
   | Local_docker _ -> `Local_docker
+  | Aws_batch_queue _ -> `Aws_batch_queue
 
 let save ~storage:st cluster =
   Storage.Json.save_jsonable
@@ -28,10 +30,13 @@ let gke k = Kube k
 
 let local_docker ~max_jobs = Local_docker {max_jobs}
 
+let aws_batch_queue abq = Aws_batch_queue abq
+
 let max_started_jobs =
   function
   | Kube k -> Gke_cluster.max_started_jobs k
   | Local_docker { max_jobs } -> max_jobs
+  | Aws_batch_queue a -> Aws_batch_queue.max_started_jobs a
 
 let ensure_living t ~log =
   match t with
@@ -39,17 +44,23 @@ let ensure_living t ~log =
   | Local_docker _ ->
     (* TODO: check docker exists and is ready *)
     return ()
+  | Aws_batch_queue q ->
+    Aws_batch_queue.ensure_living ~log q
 
 let display_name =
   function
   | Kube k ->
     sprintf "GCloud-Kube-%s@%s" k.Gke_cluster.name k.Gke_cluster.zone
   | Local_docker { max_jobs } -> sprintf "Localdocker_Max-%d" max_jobs
+  | Aws_batch_queue a ->
+    sprintf "Aws-batch-queue-%s" (Aws_batch_queue.queue_name a)
 
 let do_log_t f ~log =
   function
   | Kube k -> f ~log k
   | Local_docker _ -> return ()
+  | Aws_batch_queue _ ->
+    return ()
 
 let start ~log t =
   do_log_t Gke_cluster.gcloud_start ~log t
@@ -60,4 +71,6 @@ let describe ~log =
   function
   | Kube k -> Gke_cluster.gcloud_describe ~log k
   | Local_docker _ as t -> return (display_name t, "")
+  | Aws_batch_queue a ->
+    return (display_name t, "")
 

--- a/src/lib/error.ml
+++ b/src/lib/error.ml
@@ -18,15 +18,24 @@ let to_string =
     Kube_job.Error.to_string e
   | `Job (`Docker_inspect_json_parsing _ as e) ->
     Local_docker_job.Error.to_string e
+  | `Job (`Missing_aws_state id) ->
+    sprintf "Job %s is missing AWS-Batch data" id
   | `Start_server (`Exn e) ->
     sprintf "Starting Cohttp server: %s" (exn e)
   | `Client err -> Client.Error.to_string err
   | `Invalid_job_submission (`Wrong_backend (job, clu)) ->
     let disp =
       function
+      | `Aws_batch_queue -> "AWS-Batch-Queue"
+      | `Aws_batch -> "AWS-Batch-Job"
       | `Kube -> "Kubernetes"
       | `GCloud_kubernetes -> "GCloud-kubernetes"
       | `Local_docker -> "Local-Docker" in
     sprintf "Invalid job submission: backend mismatch: \
              job wants %s, cluster is %s"
       (disp job) (disp clu)
+   | `Aws_batch_queue (`Check_valid, out, err) ->
+     sprintf "Invalid AWS job-queue: %S (stderr: %S)" out err
+   | `Aws_batch_job ((`Start _ | `Status _) as ae) ->
+     sprintf "AWS-Batch-Job error: %s" (Aws_batch_job.Error.show ae)
+

--- a/src/lib/job.ml
+++ b/src/lib/job.ml
@@ -4,13 +4,17 @@ module Specification = struct
   type t =
     | Kube of Kube_job.Specification.t
     | Local_docker of Local_docker_job.Specification.t
+    | Aws_batch of Aws_batch_job.Specification.t
   [@@deriving yojson, show]
   let kind =
     function
     | Kube _ -> `Kube
     | Local_docker _ -> `Local_docker
+    | Aws_batch _ -> `Aws_batch
   let kubernetes spec = Kube spec
   let local_docker spec = Local_docker spec
+
+  let aws_batch spec = Aws_batch spec
 end
 
 module Status = struct
@@ -22,6 +26,13 @@ module Status = struct
   ] [@@deriving yojson,show ] 
 end
 
+module State = struct
+  type t =
+    | Empty
+    | Aws_batch_job of Aws_batch_job.State.t
+  [@@deriving yojson, show]
+end
+
 type t = {
   id: string;
   specification: Specification.t [@main ];
@@ -29,8 +40,11 @@ type t = {
   mutable update_errors : string list;
   mutable start_errors : string list;
   mutable latest_error: float option;
+  mutable saved_state: State.t [@default State.Empty];
 }
 [@@deriving yojson, show, make]
+
+let make ~id spec = make ~id spec
 
 let id t = t.id
 let status t = t.status
@@ -60,6 +74,7 @@ let make_path id =
   function
   | `Specification -> ["job"; id; "specification.json"]
   | `Status -> ["job"; id; "status.json"]
+  | `Saved_state -> ["job"; id; "saved_state.json"]
   | `Describe_output -> ["job"; id; "describe.out"]
   | `Logs_output -> ["job"; id; "logs.out"]
 
@@ -71,6 +86,10 @@ let save st job =
   Storage.Json.save_jsonable st
     ~path:(make_path (id job) `Status)
     (Status.to_yojson job.status)
+  >>= fun () ->
+  Storage.Json.save_jsonable st
+    ~path:(make_path (id job) `Saved_state)
+    (State.to_yojson job.saved_state)
 
 let get st job_id =
   Storage.Json.get_json st
@@ -81,11 +100,20 @@ let get st job_id =
     ~path:(make_path job_id `Status)
     ~parse:Status.of_yojson
   >>= fun status ->
+  Storage.Json.get_json st
+    ~path:(make_path job_id `Saved_state)
+    ~parse:State.of_yojson
+  >>= fun saved_state ->
   return {id = job_id; specification; status;
           update_errors = []; start_errors = [];
-          latest_error = None}
+          latest_error = None; saved_state}
 
 let kind t = Specification.kind t.specification
+
+let aws_state t =
+  match t.saved_state with
+  | State.Empty -> fail (`Job (`Missing_aws_state t.id))
+  | State.Aws_batch_job s -> return s
 
 let get_logs ~storage ~log t =
   match kind t with
@@ -94,6 +122,10 @@ let get_logs ~storage ~log t =
     Kube_job.get_logs ~storage ~log ~id:t.id ~save_path
   | `Local_docker ->
     Local_docker_job.get_logs ~log ~id:t.id
+  | `Aws_batch ->
+    aws_state t
+    >>= fun state ->
+    Aws_batch_job.get_logs ~log ~id:t.id ~state
 
 let describe ~storage ~log t =
   match kind t with
@@ -102,6 +134,10 @@ let describe ~storage ~log t =
     Kube_job.describe ~storage ~log ~id:t.id ~save_path
   | `Local_docker ->
     Local_docker_job.describe ~log ~id:t.id
+  | `Aws_batch ->
+    aws_state t
+    >>= fun state ->
+    Aws_batch_job.describe ~log ~id:t.id ~state
 
 let kill ~log t =
   match kind t with
@@ -109,13 +145,22 @@ let kill ~log t =
     Kube_job.kill ~log ~id:t.id
   | `Local_docker ->
     Local_docker_job.kill ~log ~id:t.id
+  | `Aws_batch ->
+    aws_state t
+    >>= fun state ->
+    Aws_batch_job.kill ~log ~id:t.id ~state
 
-let start ~log t =
+let start ~log t ~cluster =
   match t.specification with
   | Specification.Kube specification ->
     Kube_job.start ~log ~id:t.id ~specification
   | Specification.Local_docker specification ->
     Local_docker_job.start ~log ~id:t.id ~specification
+  | Specification.Aws_batch specification ->
+    Aws_batch_job.start ~cluster ~log ~id:t.id ~specification
+    >>= fun aws_state ->
+    t.saved_state <- State.Aws_batch_job aws_state;
+    return ()
 
 let get_update ~log t =
   match kind t with
@@ -135,3 +180,7 @@ let get_update ~log t =
     end
   | `Local_docker ->
     Local_docker_job.get_update ~log ~id:t.id
+  | `Aws_batch ->
+    aws_state t
+    >>= fun state ->
+    Aws_batch_job.get_update ~log ~id:t.id ~state

--- a/src/lib/server.ml
+++ b/src/lib/server.ml
@@ -167,6 +167,7 @@ let incoming_job t string =
   begin match Job.Specification.kind spec, Cluster.kind t.cluster with
   | (`Kube, `GCloud_kubernetes) -> return ()
   | (`Local_docker, `Local_docker) -> return ()
+  | (`Aws_batch, `Aws_batch_queue) -> return ()
   | tuple -> (* we could run local-docker jobs with a kube cluster but that would
             mess with the maximum number of jobs to submit *)
     fail (`Invalid_job_submission (`Wrong_backend tuple))
@@ -277,7 +278,7 @@ let rec loop:
         >>= fun () ->
         Job.save t.storage j
       | `Start j ->
-        Job.start ~log:t.log j
+        Job.start ~log:t.log j ~cluster:t.cluster
         >>< begin function
         | `Ok () -> 
           Job.set_status ~from_error:false j @@ `Started (now ());

--- a/src/lib/server.mli
+++ b/src/lib/server.mli
@@ -44,5 +44,6 @@ val create :
 val start: t ->
   (unit,
    [> `Shell_command of Hyper_shell.Error.t
+   | `Aws_batch_queue of [> `Check_valid ] * string * string
    | `Log of Log.Error.t
    | `Storage of [> Storage.Error.common ] ]) Deferred_result.t

--- a/src/test/client_server.ml
+++ b/src/test/client_server.ml
@@ -8,29 +8,26 @@ let test_out fmt =
 let failf fmt =
   ksprintf (fun s -> Lwt.fail (Failure s)) fmt
 
-let root = "_test/root"
-let port = "8082"
-
 let command ~bin args : Lwt_process.command =
   (bin, Array.of_list (bin :: args))
 
 let coclobas args : Lwt_process.command =
   command ~bin:"./coclobas.byte" args
 
-let make_url path =
-  sprintf "http://localhost:%s/%s" port path
+let make_url port path =
+  sprintf "http://localhost:%d/%s" port path
 
-let curl ?post path =
+let curl ?post ~port path =
   command ~bin:"curl" (
-    [make_url path]
+    [make_url port path]
     @ Option.value_map ~default:[] post ~f:(fun d ->
         ["--data-binary"; d])
   )
 
-let rec curl_status_until_ready acc =
+let rec curl_status_until_ready ~port acc =
   let open Lwt in
   let curl_status =
-    Lwt_process.open_process_in (curl "status")
+    Lwt_process.open_process_in (curl ~port "status")
       ~stderr:`Dev_null
   in
   Lwt_io.read_lines curl_status#stdout |> Lwt_stream.to_list
@@ -43,14 +40,14 @@ let rec curl_status_until_ready acc =
   | ["Initializing"] ->
     Lwt_unix.sleep 1.
     >>= fun () ->
-    curl_status_until_ready ("Initializing" :: acc)
+    curl_status_until_ready ~port ("Initializing" :: acc)
   | other ->
     failf "Curl /status: %s" (String.concat ~sep:"." curl_lines);
   end
 
-module Coclojob = Coclobas.Kube_job.Specification
+module Coclojob = Coclobas.Job.Specification
 
-let submit_job how job =
+let submit_job ~port how job =
   let open Lwt in
   match how with
   | `Curl ->
@@ -58,7 +55,7 @@ let submit_job how job =
     let process =
       Lwt_process.open_process_in
         ~stderr:`Dev_null
-        (curl ~post "job/submit")
+        (curl ~port ~post "job/submit")
     in
     Lwt_io.read_lines process#stdout |> Lwt_stream.to_list
     >>= fun lines ->
@@ -66,10 +63,7 @@ let submit_job how job =
       (Coclojob.show job) (String.concat ~sep:", " lines);
     return (List.hd_exn lines)
   | `Client ->
-    Coclobas.Client.(
-      submit_job
-        (make (make_url ""))
-        (Coclobas.Job.Specification.kubernetes job)
+    Coclobas.Client.(submit_job (make (make_url port "")) job
       >>= fun res ->
       match res with
       | `Ok id -> return id
@@ -78,20 +72,20 @@ let submit_job how job =
 
 let curl_submit_job job = submit_job `Curl job
 
-let get_status how ids =
+let get_status how ids ~port =
   let open Lwt in
   begin match how with
   | `Curl ->
     let process =
       Lwt_process.open_process_in ~stderr:`Dev_null
-        (ksprintf curl "job/status?%s"
+        (ksprintf (curl ~port) "job/status?%s"
            (List.map ids ~f:(sprintf "id=%s") |> String.concat ~sep:"&"))
     in
     Lwt_io.read_lines process#stdout |> Lwt_stream.to_list
   | `Client ->
     Coclobas.Client.(
       get_job_statuses
-        (make (make_url ""))
+        (make (make_url port ""))
         ids
       >>= fun res ->
       match res with
@@ -107,11 +101,11 @@ let get_status how ids =
     (String.concat ~sep:"\n" lines);
   return ()
 
-let curl_get_description ids =
+let curl_get_description ids ~port =
   let open Lwt in
   let process =
     Lwt_process.open_process_in ~stderr:`Dev_null
-      (ksprintf curl "job/describe?%s"
+      (ksprintf (curl ~port) "job/describe?%s"
          (List.map ids ~f:(sprintf "id=%s") |> String.concat ~sep:"&"))
   in
   Lwt_io.read_lines process#stdout |> Lwt_stream.to_list
@@ -121,12 +115,25 @@ let curl_get_description ids =
     (String.concat ~sep:"\n" lines);
   return ()
 
-
-let curl_kill ids =
+let curl_get_logs ids ~port =
   let open Lwt in
   let process =
     Lwt_process.open_process_in ~stderr:`Dev_null
-      (ksprintf curl "job/kill?%s"
+      (ksprintf (curl ~port) "job/logs?%s"
+         (List.map ids ~f:(sprintf "id=%s") |> String.concat ~sep:"&"))
+  in
+  Lwt_io.read_lines process#stdout |> Lwt_stream.to_list
+  >>= fun lines ->
+  test_out "curl_descr %s: %s"
+    (String.concat ~sep:", " ids)
+    (String.concat ~sep:"\n" lines);
+  return ()
+
+let curl_kill ids ~port =
+  let open Lwt in
+  let process =
+    Lwt_process.open_process_in ~stderr:`Dev_null
+      (ksprintf (curl ~port) "job/kill?%s"
          (List.map ids ~f:(sprintf "id=%s") |> String.concat ~sep:"&"))
   in
   Lwt_io.read_lines process#stdout |> Lwt_stream.to_list
@@ -136,13 +143,17 @@ let curl_kill ids =
     (String.concat ~sep:"\n" lines);
   return ()
 
-let config =
-  coclobas [
-    "config"; "--root"; root;
-    "--cluster-name"; "sm-coclotest";
-    "--cluster-zone"; "us-east1-c";
-    "--max-nodes"; "5";
-  ]
+
+let make_test_job ~kind cmd =
+  let image = "hammerlab/keredofi:epidisco-dev" in
+  let open Coclobas in
+  match kind with
+  | `Aws_batch_queue ->
+    Aws_batch_job.Specification.make ~image cmd |> Job.Specification.aws_batch
+  | `GCloud_kubernetes ->
+    Kube_job.Specification.make ~image cmd |> Job.Specification.kubernetes
+  | `Local_docker ->
+    Local_docker_job.Specification.make ~image cmd |> Job.Specification.local_docker
 
 let job_with_nfs () =
   begin try
@@ -151,68 +162,105 @@ let job_with_nfs () =
       |> String.split ~on:(`Character ',')
       |> function
       | host :: path :: witness :: point :: [] ->
-        Coclojob.Nfs_mount.make
+        Coclobas.Kube_job.Specification.Nfs_mount.make
           ~host ~path ~point (),
         sprintf "%s/%s" point witness
       | _ -> failwith "can't parse"
     in
     Some (
-      Coclojob.make
-        ~image:"ubuntu"
-        ~volume_mounts:[`Nfs mount]
-        ["ls"; "-la"; witness]
+      Coclojob.kubernetes
+        (Coclobas.Kube_job.Specification.make
+           ~image:"ubuntu"
+           ~volume_mounts:[`Nfs mount]
+           ["ls"; "-la"; witness])
     )
   with _ -> None
   end
 
+type test_config = {
+  root: string;
+  port: int [@default 22822];
+} [@@deriving cmdliner]
 
 let () =
-  Lwt_main.run Lwt.(
-      let conf = Lwt_process.open_process_none config in
-      conf#close
-      >>= fun _ ->
-      let server_process =
-        Lwt_process.open_process_none
-          (coclobas ["start-server"; "--root"; root; "--port"; port])
-      in
-      test_out "Server started";
-      Lwt_unix.sleep 1.
-      >>= fun () ->
-      Lwt.pick [
-        curl_status_until_ready [];
-        Lwt_unix.sleep 12.
-      ]
-      >>= fun () ->
-      curl_submit_job (Coclojob.make ~image:"ubuntu" ["sleep"; "42"])
-      >>= fun sleep_42 ->
-      submit_job `Client (Coclojob.make ~image:"ubuntu" ["du"; "-sh"; "/usr"])
-      >>= fun du_sh_usr ->
-      get_status `Curl [sleep_42; du_sh_usr]
-      >>= fun () ->
-      Lwt_unix.sleep 5. >>= fun () ->
-      get_status `Client [sleep_42; du_sh_usr]
-      >>= fun () ->
-      curl_kill [sleep_42]
-      >>= fun () ->
-      Lwt_unix.sleep 5. >>= fun () ->
-      curl_get_description [sleep_42; du_sh_usr]
-      >>= fun () ->
-      Option.value_map ~default:(return ()) (job_with_nfs ())
-        ~f:begin fun job ->
-          curl_submit_job job
-          >>= fun id ->
-          get_status `Curl [id]
-          >>= fun () ->
-          Lwt_unix.sleep 5.
-          >>= fun () ->
-          get_status `Client [id]
+  let main {root; port} = 
+    Lwt_main.run Lwt.(
+        let server_process =
+          Lwt_process.open_process_none
+            (coclobas ["start-server"; "--root"; root;
+                       "--port"; Int.to_string port])
+        in
+        test_out "Server started";
+        Lwt_unix.sleep 1.
+        >>= fun () ->
+        Lwt.pick [
+          curl_status_until_ready ~port [];
+          begin
+            Lwt_unix.sleep 12.
+            >>= fun () ->
+            Lwt.fail_with "curl_status_until_ready timedout"
+          end;
+        ]
+        >>= fun () ->
+        begin
+          Pvem_lwt_unix.Deferred_result.(
+            Coclobas.Command_line.get_cluster ~root
+            >>| Coclobas.Cluster.kind
+          )
+          >>= function
+          | `Ok k -> return k
+          | `Error e -> Coclobas.Error.to_string e |> Lwt.fail_with
         end
-      >>= fun () ->
-      Lwt_unix.sleep 500.
-      >>= fun () ->
-      test_out "Killing server";
-      server_process#kill Sys.sigint;
-      server_process#close
-      >>= fun _ ->
-      return ()
-    )
+        >>= fun kind ->
+        curl_submit_job ~port (make_test_job ~kind ["sleep"; "400"])
+        >>= fun sleep_42 ->
+        submit_job `Client ~port (make_test_job ~kind [
+            "sh"; "-c"; "whoami ; \
+                         du -sh /usr ; \
+                         curl http://169.254.169.254/latest/meta-data/ \
+                        "])
+        >>= fun du_sh_usr ->
+        get_status ~port `Curl [sleep_42; du_sh_usr]
+        >>= fun () ->
+        Lwt_unix.sleep 5. >>= fun () ->
+        get_status ~port `Client [sleep_42; du_sh_usr]
+        >>= fun () ->
+        curl_kill ~port [sleep_42]
+        >>= fun () ->
+        Lwt_unix.sleep 5. >>= fun () ->
+        curl_get_description ~port [sleep_42; du_sh_usr]
+        >>= fun () ->
+        Option.value_map ~default:(return ()) (job_with_nfs ())
+          ~f:begin fun job ->
+            curl_submit_job job ~port
+            >>= fun id ->
+            get_status `Curl [id] ~port
+            >>= fun () ->
+            Lwt_unix.sleep 5.
+            >>= fun () ->
+            get_status `Client [id] ~port
+          end
+        >>= fun () ->
+        Lwt_unix.sleep 50.
+        >>= fun () ->
+        curl_get_description ~port [sleep_42; du_sh_usr]
+        >>= fun () ->
+        curl_get_logs ~port [sleep_42; du_sh_usr]
+        >>= fun () ->
+        test_out "Killing server";
+        server_process#kill Sys.sigint;
+        server_process#close
+        >>= fun _ ->
+        return ()
+      )
+  in
+  match Cmdliner.Term.(eval (
+      (pure main $ test_config_cmdliner_term ()),
+      info "coclobas-client-server-test"
+        ~doc:"A test that starts a server and talks to it."))
+  with
+  | `Error _ -> exit 1
+  | `Ok ()
+  | `Version
+  | `Help -> exit 0
+

--- a/src/test/workflow_test.ml
+++ b/src/test/workflow_test.ml
@@ -1,40 +1,68 @@
 
 open Nonstd
 
-let which_ones =
-  match Sys.getenv "kind" with
-  | "local-docker" -> `Local_docker
-  | "kubernetes" -> `Kubernetes
-  | other -> `All
-  | exception _ -> `All
+type params = {
+  port: int [@env "PORT"];
+  test_kind: [ `Local_docker | `Kubernetes | `Aws_batch ]
+      [@enum [ "local-docker", `Local_docker;
+               "kubernetes", `Kubernetes;
+               "aws-batch", `Aws_batch ]];
+} [@@deriving cmdliner]
 
-let () =
-  let base_url = "http://127.0.0.1:8082" in
+let main {port; test_kind} =
+  let base_url = sprintf "http://127.0.0.1:%d" port in
   let tags more = "coclobas" :: "test" :: more in
+  let open Ketrew.EDSL in
+  let of_command expect_tag cmd =
+    workflow_node without_product
+      ~name:(sprintf "Coclobas test should %s" expect_tag)
+      ~tags:(tags ["should-" ^ expect_tag])
+      ~make:(
+        match test_kind with
+        | `Aws_batch ->
+          Coclobas_ketrew_backend.Plugin.create
+            ~base_url
+            (Coclobas.Aws_batch_job.Specification.make ~image:"ubuntu" cmd
+             |> Coclobas.Job.Specification.aws_batch)
+        | `Kubernetes ->
+          Coclobas_ketrew_backend.Plugin.create
+            ~base_url
+            (Coclobas.Kube_job.Specification.make ~image:"ubuntu" cmd
+             |> Coclobas.Job.Specification.kubernetes)
+        | `Local_docker ->
+          Coclobas_ketrew_backend.Plugin.create
+            ~base_url
+            (Coclobas.Local_docker_job.Specification.make ~image:"ubuntu" cmd
+             |> Coclobas.Job.Specification.local_docker)
+      )
+  in
+  let of_program tag p =
+    let prog_string = Ketrew_pure.Program.to_single_shell_command p in
+    workflow_node without_product
+      ~name:(sprintf "Coclobas test uses Program.t (%d bytes)"
+               (String.length prog_string))
+      ~tags:(tags ["should-" ^ tag; "program"])
+      ~make:(
+        match test_kind with
+        | `Aws_batch ->
+          let cmd = ["bash"; "-c"; prog_string] in
+          Coclobas_ketrew_backend.Plugin.create
+            ~base_url
+            (Coclobas.Aws_batch_job.Specification.make ~image:"ubuntu" cmd
+             |> Coclobas.Job.Specification.aws_batch)
+        | `Kubernetes ->
+          Coclobas_ketrew_backend.Plugin.kubernetes_program
+            ~base_url
+            ~image:"ubuntu" p
+        | `Local_docker ->
+          Coclobas_ketrew_backend.Plugin.local_docker_program
+            ~base_url
+            ~image:"ubuntu" p
+      )
+  in
   let wf =
-    let open Ketrew.EDSL in
-    let node1 =
-      workflow_node without_product
-        ~name:"Coclobas test should succeed"
-        ~tags:(tags ["succeeds"])
-        ~make:(
-          Coclobas_ketrew_backend.Plugin.create
-            ~base_url
-            (Coclobas.Kube_job.Specification.make ~image:"ubuntu" ["ls"; "-la"]
-             |> Coclobas.Job.Specification.kubernetes)
-        )
-    in
-    let node2 =
-      workflow_node without_product
-        ~name:"Coclobas test should fail"
-        ~tags:(tags ["fails"])
-        ~make:(
-          Coclobas_ketrew_backend.Plugin.create
-            ~base_url
-            (Coclobas.Kube_job.Specification.make ~image:"ubuntu" ["exit"; "1"]
-             |> Coclobas.Job.Specification.kubernetes)
-        )
-    in
+    let node1 = of_command "succeed" ["ls"; "-la"] in
+    let node2 = of_command "fail" ["exit"; "1"] in
     let node3 =
       workflow_node without_product
         ~name:"Coclobas test uses secret"
@@ -56,24 +84,19 @@ let () =
                ))
         )
     in
-    let node4 =
-      workflow_node without_product
-        ~name:"Coclobas test uses Program.t"
-        ~tags:(tags ["succeeds"; "program"])
-        ~make:(
-          Coclobas_ketrew_backend.Plugin.kubernetes_program
-            ~base_url
-            ~image:"ubuntu"
-            Program.(
-              chain [
-                shf "whoami";
-                shf "hostname";
-                shf "echo \"ketrew playground: $KETREW_PLAYGROUND\"";
-                shf "sleep 60";
-              ]
-            )
+    let node4 = of_program "succeed" Program.(
+        chain [
+          shf "whoami";
+          shf "hostname";
+          shf "echo \"ketrew playground: $KETREW_PLAYGROUND\"";
+          shf "sleep 60";
+        ]
+      ) in
+    let node4big = of_program "succeed" Program.(
+        chain (
+          List.init 100 ~f:(fun i -> shf "echo 'This is the command %d'" i)
         )
-    in
+      ) in
     let node5 =
       workflow_node without_product
         ~name:"Coclobas test local-docker"
@@ -119,23 +142,44 @@ let () =
     in
     let kubes = [
       depends_on node1;
-        depends_on node2;
-        depends_on node3;
-        depends_on node4;
+      depends_on node2;
+      depends_on node3;
+      depends_on node4;
+      depends_on node4big;
     ] in
     let locals = [
-        depends_on node5;
-        depends_on node6;
-        depends_on node7;
-      ] in
+      depends_on node1;
+      depends_on node2;
+      depends_on node4;
+      depends_on node4big;
+      depends_on node5;
+      depends_on node6;
+      depends_on node7;
+    ] in
+    let aws = [
+      depends_on node1;
+      depends_on node2;
+      depends_on node4;
+      depends_on node4big;
+    ] in
     let edges =
-      match which_ones with
+      match test_kind with
       | `Kubernetes -> kubes
       | `Local_docker -> locals
-      | `All -> kubes @ locals in
+      | `Aws_batch -> aws in
     workflow_node without_product
       ~tags:(tags ["fails"; "toplevel"])
       ~name:"Coclobas test workflow"
       ~edges
   in
   Ketrew.Client.submit_workflow wf
+
+let () =
+  match
+    Cmdliner.Term.(eval
+                     (pure main $ params_cmdliner_term (), info "test-workflow"))
+  with
+  | `Error _ -> exit 1
+  | `Ok ()
+  | `Version
+  | `Help -> exit 0


### PR DESCRIPTION
The notion of cluster is an AWS Batch “job-queue,” Coclobas does not
create it but it checks that it's there; and fails at start-up if it
isn't “`VALID`”.

The `get_logs` function, does not et the logs, it instead generates a
URL to visit on <https://console.aws.amazon.com/cloudwatch>.

The tests now depend on (and use) `ppx_deriving_cmdliner`.

The plugin is for now very basic: it only runs commands and does not
understand `Program.t` values since there is no easy way of “mounting
data” on the containers.

When we go over-size for the command AWS-Batch fails with:

> An error occurred (ClientException) when calling the
> RegisterJobDefinition operation: Error executing request, Exception :
> Limits Error: JobDefinitionsize is above the limits 20 KB

For now, downstream users of the plugin should use other means to get
bigger scripts to run (e.g. use S3 or mount an EFS filer).

Killing jobs appears to work but it is somewhat fragile because AWS does
not really “confirm” the killing cf. issue
[`aws/aws-cli#2551`](https://github.com/aws/aws-cli/issues/2551)
(also, jobs take quite a while to change status in case of killing).