### PR TITLE
Aws-job scripts + better display of the job's state

### DIFF
--- a/src/lib/aws_batch_queue.ml
+++ b/src/lib/aws_batch_queue.ml
@@ -3,11 +3,14 @@ open Internal_pervasives
 type t = {
   max_jobs: int;
   queue_name: string;
+  s3_bucket: string option;
 } [@@deriving make, yojson, show]
 
 let max_started_jobs t = t.max_jobs
 
 let queue_name t = t.queue_name
+
+let s3_bucket t = t.s3_bucket
 
 let command_must_succeed ~log cluster cmd =
   Hyper_shell.command_must_succeed ~log cmd

--- a/src/lib/client.ml
+++ b/src/lib/client.ml
@@ -76,9 +76,9 @@ let get_job_json_one_key t ~path ~ids ~json_key ~of_yojson =
   | other -> fail (`Client (`Json_parsing (uri, "Not a List", other)))
   end
 
-let get_job_statuses t ids =
-  get_job_json_one_key t ~path:"job/status" ~ids ~json_key:"status"
-    ~of_yojson:Job.Status.of_yojson
+let get_job_states t ids =
+  get_job_json_one_key t ~path:"job/state" ~ids ~json_key:"state"
+    ~of_yojson:Job.of_yojson
 
 let get_json_keys ~uri ~parsers json =
   begin match json with

--- a/src/lib/command_line.ml
+++ b/src/lib/command_line.ml
@@ -64,10 +64,10 @@ let client ~base_url action ids =
                   %s\n\n" id f d)
     |> return
   | `Status ->
-    Client.get_job_statuses client ids
-    >>= fun statuses ->
-    List.iter statuses ~f:(fun (r, s) ->
-      printf "%s is %s\n" r (Job.Status.show s))
+    Client.get_job_states client ids
+    >>= fun jobs ->
+    List.iter jobs ~f:(fun (r, s) ->
+      printf "%s is %s\n" r (Job.Status.show (Job.status s)))
     |> return
   | `List ->
     Client.get_job_list client

--- a/src/lib/command_line.ml
+++ b/src/lib/command_line.ml
@@ -165,6 +165,7 @@ let main () =
       (`GCloud_kube_name gke_name)
       (`GCloud_zone gzone)
       (`Aws_queue_name queue_name)
+      (`Aws_s3_bucket s3_bucket)
       (`Max_nodes max_nodes)
       (`Machine_type machine_type) ->
       let i_need opt msg =
@@ -183,7 +184,7 @@ let main () =
       | `Local_docker ->
         Cluster.local_docker ~max_jobs:max_nodes
       | `Aws_batch_queue ->
-        Aws_batch_queue.make ~max_jobs:max_nodes
+        Aws_batch_queue.make () ~max_jobs:max_nodes ?s3_bucket
           ~queue_name:(i_need queue_name "A AWS-Batch queue name is required \
                                           for AWS-Batch-Queue clusters.")
         |> Cluster.aws_batch_queue
@@ -202,6 +203,9 @@ let main () =
       ~doc:"Zone of the GCloud-Kubernetes cluster."
     $ optional_string "aws-queue-name" (fun s -> `Aws_queue_name s)
       ~doc:"The name (or ARN) of the AWS-Batch queue."
+    $ optional_string "aws-s3-bucket" (fun s -> `Aws_s3_bucket s)
+      ~doc:"The prefix URI of an optional S3 bucket used by the AWS-Batch \
+            backend to store scripts and other data."
     $ begin
       pure (fun s -> `Max_nodes s)
       $ Arg.(

--- a/src/lib/job.ml
+++ b/src/lib/job.ml
@@ -72,41 +72,19 @@ let fresh spec =
 let make_path id =
   (* TODO: use this in Kube_jobs uses of `~section` *)
   function
-  | `Specification -> ["job"; id; "specification.json"]
-  | `Status -> ["job"; id; "status.json"]
   | `Saved_state -> ["job"; id; "saved_state.json"]
   | `Describe_output -> ["job"; id; "describe.out"]
   | `Logs_output -> ["job"; id; "logs.out"]
 
 let save st job =
   Storage.Json.save_jsonable st
-    ~path:(make_path (id job) `Specification)
-    (Specification.to_yojson job.specification)
-  >>= fun () ->
-  Storage.Json.save_jsonable st
-    ~path:(make_path (id job) `Status)
-    (Status.to_yojson job.status)
-  >>= fun () ->
-  Storage.Json.save_jsonable st
     ~path:(make_path (id job) `Saved_state)
-    (State.to_yojson job.saved_state)
+    (to_yojson job)
 
 let get st job_id =
   Storage.Json.get_json st
-    ~path:(make_path job_id `Specification)
-    ~parse:Specification.of_yojson
-  >>= fun specification ->
-  Storage.Json.get_json st
-    ~path:(make_path job_id `Status)
-    ~parse:Status.of_yojson
-  >>= fun status ->
-  Storage.Json.get_json st
     ~path:(make_path job_id `Saved_state)
-    ~parse:State.of_yojson
-  >>= fun saved_state ->
-  return {id = job_id; specification; status;
-          update_errors = []; start_errors = [];
-          latest_error = None; saved_state}
+    ~parse:of_yojson
 
 let kind t = Specification.kind t.specification
 

--- a/src/lib/job.mli
+++ b/src/lib/job.mli
@@ -20,16 +20,10 @@ module Specification : sig
 end
 
 type t
+[@@deriving yojson,show ] 
 
-val show : t -> string
- 
-val make :
-  id: string ->
-  (* ?status: Status.t -> *)
-  (* ?update_errors: string list -> *)
-  (* ?start_errors: string list -> *)
-  (* ?latest_error: float -> *)
-  Specification.t -> t
+val make : id: string -> Specification.t -> t
+  
 
 val id : t -> string
 val status : t -> Status.t

--- a/src/lib/kube_job.mli
+++ b/src/lib/kube_job.mli
@@ -8,7 +8,7 @@ module Specification : sig
       path : string;
       point : string;
       read_only : bool;
-    }
+    } [@@deriving yojson, show, make]
     val show : t -> Ppx_deriving_runtime.string
     val make :
       host:string ->
@@ -21,6 +21,7 @@ module Specification : sig
   end
   module File_contents_mount : sig
     type t = { path : string; contents : string; }
+    [@@deriving yojson, show, make]
     val show : t -> Ppx_deriving_runtime.string
     val make : path:string -> string -> t
     val path : t -> string

--- a/src/lib/server.ml
+++ b/src/lib/server.ml
@@ -377,13 +377,13 @@ let initialization t =
   Lwt.async (fun () -> loop t);
   return ()
 
-let get_job_status t ids =
+let get_job_state t ids =
   Deferred_list.while_sequential ids ~f:(fun id ->
       Job.get t.storage id
       >>= fun job ->
       return (`Assoc [
           "id", `String id;
-          "status", Job.status job |> Job.Status.to_yojson;
+          "state", Job.to_yojson job;
         ]))
   >>= fun l ->
   return (`Json (`List l))
@@ -488,8 +488,8 @@ let start t =
             empty_logs t |> respond_result
           | "/jobs" ->
             get_jobs t |> respond_result
-          | "/job/status" ->
-            get_job_status t (job_ids_of_uri uri) |> respond_result
+          | "/job/state" ->
+            get_job_state t (job_ids_of_uri uri) |> respond_result
           | "/job/logs" ->
             get_job_logs t (job_ids_of_uri uri) |> respond_result
           | "/job/describe" ->

--- a/src/test/client_server.ml
+++ b/src/test/client_server.ml
@@ -84,14 +84,14 @@ let get_status how ids ~port =
     Lwt_io.read_lines process#stdout |> Lwt_stream.to_list
   | `Client ->
     Coclobas.Client.(
-      get_job_statuses
+      get_job_states
         (make (make_url port ""))
         ids
       >>= fun res ->
       match res with
       | `Ok stats ->
         return (List.map stats ~f:(fun (id, st) ->
-            sprintf "%s: %s" id (Coclobas.Job.Status.show st)))
+            sprintf "%s: %s" id Coclobas.Job.(Status.show (status st))))
       | `Error (`Client c) -> failf "Client error: %s" (Error.to_string c)
     )
   end

--- a/src/test/workflow_test.ml
+++ b/src/test/workflow_test.ml
@@ -45,11 +45,9 @@ let main {port; test_kind} =
       ~make:(
         match test_kind with
         | `Aws_batch ->
-          let cmd = ["bash"; "-c"; prog_string] in
-          Coclobas_ketrew_backend.Plugin.create
+          Coclobas_ketrew_backend.Plugin.aws_batch_program
             ~base_url
-            (Coclobas.Aws_batch_job.Specification.make ~image:"ubuntu" cmd
-             |> Coclobas.Job.Specification.aws_batch)
+            ~image:"ocaml/opam" p
         | `Kubernetes ->
           Coclobas_ketrew_backend.Plugin.kubernetes_program
             ~base_url


### PR DESCRIPTION

I'm not super happy of the S3 thing but for now it seems to be the only way (I've read somewhere that AWS plans to support more options for giving data to aws-batch jobs in the future, so we'll see then).

The display improvements are for all backends actually, we can now see start-errors, while Coclobas is still retrying, in case of obvious wrong configs we can now kill earlier :)

