### PR TITLE
Make GKE-image-type configurable

### DIFF
--- a/src/lib/command_line.ml
+++ b/src/lib/command_line.ml
@@ -164,6 +164,7 @@ let main () =
       cluster_kind
       (`GCloud_kube_name gke_name)
       (`GCloud_zone gzone)
+      (`Gke_image_type image_type)
       (`Aws_queue_name queue_name)
       (`Aws_s3_bucket s3_bucket)
       (`Max_nodes max_nodes)
@@ -179,6 +180,7 @@ let main () =
           (i_need gke_name "A cluster-name is required for GKE clusters.")
           ~zone:(i_need gzone "A GCloud-zone name is required for GKE clusters.")
           ~max_nodes
+          ?image_type
           ?machine_type
         |> Cluster.gke
       | `Local_docker ->
@@ -201,6 +203,9 @@ let main () =
       ~doc:"Name of the GCloud-Kubernetes cluster."
     $ optional_string "gcloud-zone" (fun s -> `GCloud_zone s)
       ~doc:"Zone of the GCloud-Kubernetes cluster."
+    $ optional_string "gke-image-type" (fun s -> `Gke_image_type s)
+      ~doc:"Override the default `--image-type` of \
+            the GCloud-Kubernetes cluster."
     $ optional_string "aws-queue-name" (fun s -> `Aws_queue_name s)
       ~doc:"The name (or ARN) of the AWS-Batch queue."
     $ optional_string "aws-s3-bucket" (fun s -> `Aws_s3_bucket s)

--- a/src/lib/gke_cluster.mli
+++ b/src/lib/gke_cluster.mli
@@ -6,11 +6,15 @@ type t = private {
   min_nodes : int;
   max_nodes : int;
   machine_type : string;
+  image_type: string option;
 } [@@deriving yojson, show]
 
 val make :
   zone:string ->
-  ?min_nodes:int -> max_nodes:int -> ?machine_type:string -> string -> t
+  ?min_nodes:int -> max_nodes:int ->
+  ?machine_type: string ->
+  ?image_type: string ->
+  string -> t
 
 val max_started_jobs: t -> int
 (** The maximum number of jobs that Coclobas will attempt to run


### PR DESCRIPTION
This is further work on #58.

The default is to let `gcloud` choose the image-type so, to get the
previous behavior one needs:

    coclobas config ... --gke-image-type container_vm ...