### PR TITLE
Generalize saving of `logs`, `describe`

### DIFF
--- a/src/ketrew_backend/plugin.ml
+++ b/src/ketrew_backend/plugin.ml
@@ -344,20 +344,57 @@ module Long_running_implementation : Ketrew.Long_running.LONG_RUNNING = struct
     | `Error (`Client ce) ->
       fail (Ketrew_pure.Internal_pervasives.Log.verbatim (Client.Error.to_string ce))
 
-  let freshness_list_to_markup l ~how =
+  let job_query_result_to_markup l =
     let open Ketrew_pure.Internal_pervasives.Display_markup in
-    List.map l
-      ~f:(fun (`Id id, `Describe_output o, `Freshness frns) ->
-          description_list [
-            "Job-id", command id;
-            "Freshness", text frns;
-            begin match how with
-            | `Block -> "Output", code_block o
-            | `Link -> "Link", uri o
-            end;
-          ])
+    List.map l ~f:(fun (id, qr) ->
+        description_list
+          (("Job-id", command id)
+           :: List.map qr ~f:(fun (section, result) ->
+               section,
+               begin match result with
+               | `Url u -> uri u
+               | `Saved_command s ->
+                 let open Hyper_shell.Saved_command in
+                 let code_block_or_empty =
+                   function
+                   | s when String.strip s = "" -> text "Empty"
+                   | other -> code_block other in
+                 let should_display_archived = ref true in
+                 let command_and_result = [
+                   "Command", command s.command;
+                   begin match s.outcome with
+                   | `Error e ->
+                     "Error",
+                     let open Hyper_shell.Error in
+                     description_list [
+                       "STDOUT", option ~f:code_block_or_empty e.stdout;
+                       "STDERR", option ~f:code_block_or_empty e.stderr;
+                       "Status", 
+                       option e.status
+                         ~f:(text_of_stringable Pvem_lwt_unix.System.Shell.status_to_string);
+                       "Exception", option e.exn ~f:command;
+                     ]
+                   | `Ok (out, err) ->
+                     begin
+                       if Some (out ^ err) = s.archived
+                       then should_display_archived := false
+                     end;
+                     "Success", description_list [
+                       "STDOUT", code_block_or_empty out;
+                       "STDERR", code_block_or_empty err;
+                     ]
+                   end;
+                 ] in
+                 let archived =
+                   if !should_display_archived then [
+                     "Archived content", option ~f:code_block_or_empty s.archived;
+                   ] else [] in
+                 command_and_result @ archived |> description_list
+               end)))
     |> concat
     |> serialize
+
+
 
   module Markup = Ketrew_pure.Internal_pervasives.Display_markup
 
@@ -450,16 +487,12 @@ module Long_running_implementation : Ketrew.Long_running.LONG_RUNNING = struct
       | ds, `Running {job_id; _} when ds = Query_names.describe ->
         client_query begin
           Client.get_job_descriptions created.client [job_id]
-          >>| freshness_list_to_markup ~how:`Block
+          >>| job_query_result_to_markup
         end
       | ds, `Running {job_id; _} when ds = Query_names.logs ->
-        let how =
-          match Job.Specification.kind created.specification with
-          | `Aws_batch -> `Link
-          | `Kube | `Local_docker -> `Block in
         client_query begin
           Client.get_job_logs created.client [job_id]
-          >>| freshness_list_to_markup ~how
+          >>| job_query_result_to_markup
         end
       | other, _ -> fail (s "Unknown query: " % s other)
 

--- a/src/ketrew_backend/plugin.ml
+++ b/src/ketrew_backend/plugin.ml
@@ -376,7 +376,8 @@ module Long_running_implementation : Ketrew.Long_running.LONG_RUNNING = struct
                      ]
                    | `Ok (out, err) ->
                      begin
-                       if Some (out ^ err) = s.archived
+                       if Some (out ^ err) =
+                          Option.map ~f:Output_archive.to_string s.archived
                        then should_display_archived := false
                      end;
                      "Success", description_list [
@@ -386,8 +387,15 @@ module Long_running_implementation : Ketrew.Long_running.LONG_RUNNING = struct
                    end;
                  ] in
                  let archived =
+                   let display_archive a =
+                     let open Output_archive in
+                     description_list [
+                       "On", date a.date;
+                       "STDOUT", code_block_or_empty a.out;
+                       "STDERR", code_block_or_empty a.err;
+                     ] in
                    if !should_display_archived then [
-                     "Archived content", option ~f:code_block_or_empty s.archived;
+                     "Archived content", option ~f:display_archive s.archived;
                    ] else [] in
                  command_and_result @ archived |> description_list
                end)))

--- a/src/lib/command_line.ml
+++ b/src/lib/command_line.ml
@@ -58,10 +58,9 @@ let client ~base_url action ids =
     Client.get_job_descriptions client ids
     >>= fun descs ->
     List.iter descs
-      ~f:(fun (`Id id, `Describe_output d, `Freshness f) ->
+      ~f:(fun (id, d) ->
           printf "ID: %s\n\
-                  Freshness: %s\n\
-                  %s\n\n" id f d)
+                  %s\n\n" id (Job_common.Query_result.show d))
     |> return
   | `Status ->
     Client.get_job_states client ids

--- a/src/lib/hyper_shell.mli
+++ b/src/lib/hyper_shell.mli
@@ -5,7 +5,7 @@ module Error: sig
     stderr: string option;
     status: [`Exited of int | `Signaled of int | `Stopped of int] option;
     exn: string option;
-  } [@@deriving yojson,make]
+  } [@@deriving yojson,make,show]
   val to_display_string: t -> string
 end
 
@@ -28,3 +28,23 @@ val command_must_succeed :
    [> `Shell_command of Error.t
    | `Log of Log.Error.t ])
     Internal_pervasives.Deferred_result.t
+
+module Saved_command : sig
+  type t = {
+    command: string;
+    outcome: [
+      | `Ok of string * string
+      | `Error of Error.t
+    ];
+    archived: string option;
+  } [@@deriving yojson,show,make]
+  val run :
+    storage:Storage.t ->
+    log:Log.t ->
+    section:string list ->
+    cmd:string ->
+    path:Storage.key ->
+    keep_the:[ `Largest | `Latest ] ->
+    (t, [> `Log of Log.Error.t | `Storage of [> Storage.Error.common ] ])
+    Internal_pervasives.Deferred_result.t
+end

--- a/src/lib/hyper_shell.mli
+++ b/src/lib/hyper_shell.mli
@@ -30,13 +30,21 @@ val command_must_succeed :
     Internal_pervasives.Deferred_result.t
 
 module Saved_command : sig
+  module Output_archive : sig
+    type t = {
+      date: float;
+      out: string;
+      err: string;
+    } [@@deriving yojson,show,make]
+    val to_string: t -> string
+  end
   type t = {
     command: string;
     outcome: [
       | `Ok of string * string
       | `Error of Error.t
     ];
-    archived: string option;
+    archived: Output_archive.t option;
   } [@@deriving yojson,show,make]
   val run :
     storage:Storage.t ->
@@ -46,5 +54,5 @@ module Saved_command : sig
     path:Storage.key ->
     keep_the:[ `Largest | `Latest ] ->
     (t, [> `Log of Log.Error.t | `Storage of [> Storage.Error.common ] ])
-    Internal_pervasives.Deferred_result.t
+      Internal_pervasives.Deferred_result.t
 end

--- a/src/lib/internal_pervasives.ml
+++ b/src/lib/internal_pervasives.ml
@@ -11,6 +11,11 @@ let return = Deferred_result.return
 let fail = Deferred_result.fail
                
 
+let of_ocaml_result =
+  function
+  | Ok o -> return o
+  | Error s -> fail s
+
 let dbg fmt =
   ksprintf (fun s -> printf "Cocldebug>> %s\n%!" s) fmt
 

--- a/src/lib/job.mli
+++ b/src/lib/job.mli
@@ -54,8 +54,7 @@ val get_logs :
   storage:Storage.t ->
   log:Log.t ->
   t ->
-  ([ `Archived of [ `Shell_command of Hyper_shell.Error.t ] | `Fresh ] *
-   string,
+  (Job_common.Query_result.t,
    [> `Log of Log.Error.t
    | `Shell_command of Hyper_shell.Error.t
    | `Job of [> `Missing_aws_state of string ]
@@ -66,8 +65,7 @@ val describe :
   storage:Storage.t ->
   log:Log.t ->
   t ->
-  ([ `Archived of [ `Shell_command of Hyper_shell.Error.t ] | `Fresh ] *
-   string,
+  (Job_common.Query_result.t,
    [> `Log of Log.Error.t
    | `Shell_command of Hyper_shell.Error.t
    | `Job of [> `Missing_aws_state of string ]

--- a/src/lib/job_common.ml
+++ b/src/lib/job_common.ml
@@ -1,0 +1,36 @@
+open Internal_pervasives
+
+(** Common tools and function for all [Job] implementations. *)
+
+
+let job_section id = ["job"; id; "commands"]
+
+let save_path id =
+  function
+  | `Saved_state -> ["job"; id; "saved_state.json"]
+  | `Describe_output -> ["job"; id; "describe.out"]
+  | `Logs_output -> ["job"; id; "logs.out"]
+
+(** The queries [describe] and [logs] have an interesting archival
+    mechanism for their results, this module packs results together
+    (esp. for display in the Ketrew UI within the plugin). *)
+module Query_result = struct
+  type job_call_result_item = [
+    | `Saved_command of Hyper_shell.Saved_command.t
+    | `Url of string
+  ]
+  [@@deriving yojson, show]
+  type t = (string * job_call_result_item) list
+  [@@deriving yojson, show]
+  type 'a call_function =
+    storage:Storage.t ->
+    log:Log.t ->
+    id:string ->
+    (t,
+     [> `Log of Log.Error.t
+     | `Shell_command of Hyper_shell.Error.t
+     | `Storage of [> Storage.Error.common ] ] as 'a) Deferred_result.t
+
+  let one_saved name saved = [name, `Saved_command saved]
+  let one_url name saved = [name, `Url saved]
+end

--- a/src/lib/job_common.ml
+++ b/src/lib/job_common.ml
@@ -5,11 +5,14 @@ open Internal_pervasives
 
 let job_section id = ["job"; id; "commands"]
 
-let save_path id =
+let save_path ?tag id =
+  let name ?(ext = "json") s =
+    sprintf "%s%s.%s"
+      s (Option.value_map ~default:"" tag ~f:(sprintf "-%s")) ext in
   function
-  | `Saved_state -> ["job"; id; "saved_state.json"]
-  | `Describe_output -> ["job"; id; "describe.out"]
-  | `Logs_output -> ["job"; id; "logs.out"]
+  | `Saved_state -> ["job"; id; name "saved_state"]
+  | `Describe_output -> ["job"; id; name "describe"]
+  | `Logs_output -> ["job"; id; name "logs"]
 
 (** The queries [describe] and [logs] have an interesting archival
     mechanism for their results, this module packs results together

--- a/src/lib/kube_job.mli
+++ b/src/lib/kube_job.mli
@@ -46,14 +46,10 @@ val start :
    | `Log of Log.Error.t ]) Deferred_result.t
 
 val describe :
-  storage:Storage.t ->
-  log:Log.t ->
-  id:string ->
-  save_path:Storage.key ->
-  ([ `Fresh | `Archived of [ `Shell_command of Hyper_shell.Error.t ] ] * string,
-   [> `Log of Log.Error.t
-   | `Shell_command of Hyper_shell.Error.t
-   | `Storage of [> Storage.Error.common ] ]) Deferred_result.t
+  _ Job_common.Query_result.call_function
+
+val get_logs:
+  _ Job_common.Query_result.call_function
 
 val kill :
   log:Log.t ->
@@ -61,16 +57,6 @@ val kill :
   (unit,
    [> `Shell_command of Hyper_shell.Error.t
    | `Log of Log.Error.t ]) Deferred_result.t
-
-val get_logs:
-  storage:Storage.t ->
-  log:Log.t ->
-  id: string ->
-  save_path: Storage.key ->
-  ([ `Fresh | `Archived of [ `Shell_command of Hyper_shell.Error.t ] ] * string,
-   [> `Log of Log.Error.t
-   | `Shell_command of Hyper_shell.Error.t
-   | `Storage of [> Storage.Error.common ] ]) Deferred_result.t
 
 val get_status_json :
   log:Log.t ->

--- a/src/lib/local_docker_job.ml
+++ b/src/lib/local_docker_job.ml
@@ -40,15 +40,15 @@ let start ~log ~id ~specification =
      |> exec)
 
 let describe ~storage ~log ~id =
-  let save_path = Job_common.save_path id `Describe_output in
+  let save_path tag = Job_common.save_path ~tag id `Describe_output in
   Hyper_shell.Saved_command.run
-    ~storage ~log ~path:save_path
+    ~storage ~log ~path:(save_path "stats")
     ~section:(job_section id)
     ~keep_the:`Latest
     ~cmd:(["docker"; "stats"; "--no-stream"; id] |> exec)
   >>= fun stat_result ->
   Hyper_shell.Saved_command.run
-    ~storage ~log ~path:save_path
+    ~storage ~log ~path:(save_path "inspect")
     ~section:(job_section id)
     ~keep_the:`Latest
     ~cmd:(["docker"; "inspect"; id] |> exec)

--- a/src/lib/local_docker_job.ml
+++ b/src/lib/local_docker_job.ml
@@ -10,12 +10,15 @@ module Specification = struct
   } [@@deriving yojson, show, make]
 end
 
+let job_section id = ["job"; id; "commands"]
+
 let command_must_succeed ~log ?additional_json ~id cmd =
   Hyper_shell.command_must_succeed ~log cmd ?additional_json
-    ~section:["job"; id; "commands"]
+    ~section:(job_section id)
 let command_must_succeed_with_output ~log ?additional_json ~id cmd =
   Hyper_shell.command_must_succeed_with_output ~log cmd ?additional_json
-    ~section:["job"; id; "commands"]
+    ~section:(job_section id)
+
 let exec c =
   List.map c ~f:Filename.quote |> String.concat ~sep:" "
 
@@ -36,26 +39,32 @@ let start ~log ~id ~specification =
      @ specification.command
      |> exec)
 
-let always_fresh (out, err) =
-  (`Fresh, out ^ err)
+let describe ~storage ~log ~id =
+  let save_path = Job_common.save_path id `Describe_output in
+  Hyper_shell.Saved_command.run
+    ~storage ~log ~path:save_path
+    ~section:(job_section id)
+    ~keep_the:`Latest
+    ~cmd:(["docker"; "stats"; "--no-stream"; id] |> exec)
+  >>= fun stat_result ->
+  Hyper_shell.Saved_command.run
+    ~storage ~log ~path:save_path
+    ~section:(job_section id)
+    ~keep_the:`Latest
+    ~cmd:(["docker"; "inspect"; id] |> exec)
+  >>= fun inspect_result ->
+  return ["Stats", `Saved_command stat_result;
+          "Inspection", `Saved_command inspect_result]
 
-let describe ~log ~id =
-  command_must_succeed_with_output ~log ~id
-    (["docker"; "stats"; "--no-stream"; id] |> exec)
-  >>= fun (statout, staterr) ->
-  command_must_succeed_with_output ~log ~id
-    (["docker"; "inspect"; id] |> exec)
-  >>= fun (inspout, insperr) ->
-  return (always_fresh
-            (sprintf "#### Stats:\n%s\n\n\
-                      #### Inspection:\n%s\n\n\
-                      #### Errors:\n%s\n%s\n"
-               statout inspout staterr insperr, ""))
-
-let get_logs ~log ~id =
-  command_must_succeed_with_output ~log ~id
-    (["docker"; "logs"; id] |> exec)
-  >>| always_fresh
+let get_logs ~storage ~log ~id =
+  let save_path = Job_common.save_path id `Logs_output in
+  Hyper_shell.Saved_command.run
+    ~storage ~log ~path:save_path
+    ~section:(job_section id)
+    ~keep_the:`Latest
+    ~cmd:(["docker"; "logs"; id] |> exec)
+  >>= fun logres ->
+  return (Job_common.Query_result.one_saved "Logs" logres)
 
 let kill ~log ~id =
   command_must_succeed ~log ~id

--- a/src/lib/local_docker_job.mli
+++ b/src/lib/local_docker_job.mli
@@ -19,11 +19,10 @@ val start :
    | `Log of Log.Error.t ]) Deferred_result.t
 
 val describe :
-  log:Log.t ->
-  id:string ->
-  ([ `Fresh | `Archived of [ `Shell_command of Hyper_shell.Error.t ] ] * string,
-   [> `Log of Log.Error.t
-   | `Shell_command of Hyper_shell.Error.t]) Deferred_result.t
+  _ Job_common.Query_result.call_function
+
+val get_logs:
+  _ Job_common.Query_result.call_function
 
 val kill :
   log:Log.t ->
@@ -31,13 +30,6 @@ val kill :
   (unit,
    [> `Shell_command of Hyper_shell.Error.t
    | `Log of Log.Error.t ]) Deferred_result.t
-
-val get_logs:
-  log:Log.t ->
-  id: string ->
-  ([ `Fresh | `Archived of [ `Shell_command of Hyper_shell.Error.t ] ] * string,
-   [> `Log of Log.Error.t
-   | `Shell_command of Hyper_shell.Error.t]) Deferred_result.t
 
 val get_update :
   log: Log.t ->

--- a/src/lib/storage.ml
+++ b/src/lib/storage.ml
@@ -120,6 +120,13 @@ module Json = struct
     >>= fun yo ->
     of_yojson_error ~info (parse yo)
 
+  let get_json_opt st ~path ~parse =
+    read st path
+    >>= begin function
+    | Some json -> parse_json_blob ~parse json >>| fun s -> Some s
+    | None -> return None
+    end
+
   let get_json st ~path ~parse =
     read st path
     >>= begin function

--- a/src/lib/storage.mli
+++ b/src/lib/storage.mli
@@ -46,6 +46,12 @@ module Json : sig
     string ->
     ('a, [> `Storage of [> Error.common ] ]) Deferred_result.t
 
+  val get_json_opt : t -> path:key ->
+    parse:(Yojson.Safe.json ->
+           ('a, string) Ppx_deriving_yojson_runtime.Result.result) ->
+    ('a option,
+     [> `Storage of [> Error.common]])
+      Deferred_result.t
   val get_json : t -> path:key ->
     parse:(Yojson.Safe.json ->
            ('a, string) Ppx_deriving_yojson_runtime.Result.result) ->


### PR DESCRIPTION
This should completely mitigate #100 and #112, we display the archived
output only if it is different, cf. `plugin.ml`:

    if Some (out ^ err) = s.archived
    then should_display_archived := false

It also makes the saving work for the AWS and Local-docker backends.

![image](https://cloud.githubusercontent.com/assets/617111/26379115/8a962cea-3fe5-11e7-9cd9-c30dd582b79b.png)


![image](https://cloud.githubusercontent.com/assets/617111/26379131/9b46efb6-3fe5-11e7-93e2-835dc88a6016.png)



