### PR TITLE
Add CPU/memory limits to local-docker jobs

### DIFF
--- a/src/lib/local_docker_job.mli
+++ b/src/lib/local_docker_job.mli
@@ -6,6 +6,8 @@ module Specification : sig
     image: string;
     command: string list [@main];
     volume_mounts: [ `Local of string * string ] list;
+    memory: [ `GB of int | `MB of int ] option;
+    cpus: float option;
   } [@@deriving yojson, show, make]
 end
 

--- a/src/test/workflow_test.ml
+++ b/src/test/workflow_test.ml
@@ -57,6 +57,8 @@ let main {port; test_kind; additional_test} =
             ~image:(Option.value ~default:"ubuntu" image) p
         | `Local_docker ->
           Coclobas_ketrew_backend.Plugin.local_docker_program
+            ~cpus:1.5
+            ~memory:(`MB 10)
             ~base_url
             ~image:(Option.value ~default:"ubuntu" image) p
       )


### PR DESCRIPTION
This fixes issue #89.

When Docker ≥ 1.13 becomes pervasive we'll be able to use `--cpus`
instead of the quotas by “mili-CPUs.”